### PR TITLE
Add dashboard insertion in Jupyter notebooks

### DIFF
--- a/argopy/__init__.py
+++ b/argopy/__init__.py
@@ -17,6 +17,7 @@ from . import tutorial
 from . import utilities
 from .utilities import show_versions
 from .options import set_options
+from .plotters import open_dashboard as dashboard
 
 #
 __all__ = (
@@ -27,6 +28,7 @@ __all__ = (
     # Top-level functions:
     "set_options",
     "show_versions",
+    "dashboard",
     # Sub-packages,
     "utilities",
     "errors",

--- a/argopy/errors.py
+++ b/argopy/errors.py
@@ -57,3 +57,9 @@ class ErddapServerError(ValueError):
     Raise this when argopy is disrupted by an error due to the Erddap, not argopy machinery
     """
     pass
+
+class InvalidDashboard(ValueError):
+    """
+    Raise this when trying to work with a 2rd party online service to display float information
+    """
+    pass

--- a/argopy/errors.py
+++ b/argopy/errors.py
@@ -60,6 +60,6 @@ class ErddapServerError(ValueError):
 
 class InvalidDashboard(ValueError):
     """
-    Raise this when trying to work with a 2rd party online service to display float information
+    Raise this when trying to work with a 3rd party online service to display float information
     """
     pass

--- a/argopy/plotters.py
+++ b/argopy/plotters.py
@@ -47,11 +47,12 @@ if with_cartopy:
                                                facecolor=[0.4,0.6,0.7])
 
 def open_dashboard(wmo=None, cyc=None, width="100%", height=1000, url=None, type='ea'):
-    """ Insert in a notebook the Euro-Argo dashboard page for a float or a profile
+    """ Insert in a notebook the Euro-Argo dashboard page
 
         Parameters
         ----------
-        wmo : int
+        wmo: int
+            The float WMO to display. By default, this is set to None and will insert the general dashboard.
 
         Returns
         -------
@@ -63,7 +64,10 @@ def open_dashboard(wmo=None, cyc=None, width="100%", height=1000, url=None, type
     from IPython.display import IFrame
     if url is None:
         if type=='ea': # Open Euro-Argo dashboard
-            url = "https://fleetmonitoring.euro-argo.eu/float/{}".format(str(wmo))
+            if wmo is None:
+                url = "https://fleetmonitoring.euro-argo.eu"
+            else:
+                url = "https://fleetmonitoring.euro-argo.eu/float/{}".format(str(wmo))
 
         ## argovis doesn't allow X-Frame insertion !
         # elif type == 'argovis':

--- a/argopy/plotters.py
+++ b/argopy/plotters.py
@@ -9,6 +9,7 @@
 
 import numpy as np
 import warnings
+from argopy.errors import InvalidDashboard
 
 try:
     import matplotlib as mpl
@@ -44,6 +45,34 @@ if with_cartopy:
                                                name='land',
                                                scale='50m',
                                                facecolor=[0.4,0.6,0.7])
+
+def open_dashboard(wmo=None, cyc=None, width="100%", height=1000, url=None, type='ea'):
+    """ Insert in a notebook the Euro-Argo dashboard page for a float or a profile
+
+        Parameters
+        ----------
+        wmo : int
+
+        Returns
+        -------
+        IFrame: IPython.lib.display.IFrame
+    """
+    if type not in ['ea']:
+        raise InvalidDashboard("Invalid dashboard type")
+
+    from IPython.display import IFrame
+    if url is None:
+        if type=='ea': # Open Euro-Argo dashboard
+            url = "https://fleetmonitoring.euro-argo.eu/float/{}".format(str(wmo))
+
+        ## argovis doesn't allow X-Frame insertion !
+        # elif type == 'argovis':
+        #     if cyc is None:
+        #         url = "https://argovis.colorado.edu/catalog/platforms/{}/page".format(str(wmo))
+        #     else:
+        #         url = "https://argovis.colorado.edu/catalog/profiles/{}_{}/page".format(str(wmo),str(cyc))
+
+    return IFrame(url, width=width, height=height)
 
 class discrete_coloring():
     """ Handy class to manage discrete coloring and the associated colorbar

--- a/argopy/tests/test_plotters.py
+++ b/argopy/tests/test_plotters.py
@@ -1,0 +1,19 @@
+import pytest
+import unittest
+
+import argopy
+from argopy.errors import InvalidDashboard
+
+from argopy.utilities import isconnected
+CONNECTED = isconnected()
+
+@unittest.skipUnless(CONNECTED, "notebook dashboard requires an internet connection")
+def test_invalid_dashboard():
+    with pytest.raises(InvalidDashboard):
+        argopy.dashboard(wmo=5904797, type='invalid_service')
+
+@unittest.skipUnless(CONNECTED, "notebook dashboard requires an internet connection")
+def test_valid_dashboard():
+    import IPython
+    dsh = argopy.dashboard(wmo=5904797)
+    assert isinstance(dsh, IPython.lib.display.IFrame) == True

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -8,11 +8,13 @@ v0.1.4 (XX June 2020)
 
 **Features and front-end API**
 
-- Insert in a Jupyter notebook a dashboard page for a specific float (:pr:`20`).
+- Insert in a Jupyter notebook cell the `Euro-Argo fleet monitoring <https://fleetmonitoring.euro-argo.eu>`_ dashboard page, possibly for a specific float (:pr:`20`).
 
 .. code-block:: python
 
     import argopy
+    argopy.dashboard()
+    # or
     argopy.dashboard(wmo=6902746)
 
 **Breaking changes with previous versions**

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,6 +3,22 @@
 What's New
 ==========
 
+v0.1.4 (XX June 2020)
+---------------------
+
+**Features and front-end API**
+
+- Insert in a Jupyter notebook a dashboard page for a specific float (:pr:`20`).
+
+.. code-block:: python
+
+    import argopy
+    argopy.dashboard(wmo=6902746)
+
+**Breaking changes with previous versions**
+
+**Internals**
+
 v0.1.3 (15 May 2020)
 --------------------
 


### PR DESCRIPTION
This allows for the insertion in a Jupyter notebook cell of the [Euro-Argo dashboard](https://fleetmonitoring.euro-argo.eu), possibly for a given float.

This is more for experts at this points, since the Euro-Argo dashboard is targeting operators and technical data.

Usage:
```python
import argopy
argopy.dashboard()
# or
argopy.dashboard(wmo=6902746)
```

This will create a cell that look like this:
![Screenshot 2020-05-27 at 15 21 20](https://user-images.githubusercontent.com/1956032/83023843-c35f5a00-a02d-11ea-9904-58948a1d0239.png)



