### PR TITLE
add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include *.txt
+include README.md
+include LICENSE
+
+graft argopy
+
+prune binder
+prune docs
+prune *.egg-info
+
+exclude *.yml


### PR DESCRIPTION
The source tarball is not installable due to missing files. The command below will fail.

```shell
pip install argopy --no-binary :all:
```

This PR adds the missing file and the LICENSE so downstream packagers can re-package this.