### PR TITLE
use a pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 script:
   - |
     if [[ $TRAVIS_JOB_NAME == 'tarball' ]]; then
-      pip wheel . -w dist --no-deps && \
-      check-manifest --verbose && \
+      python -m pep517.build --source --binary . --out-dir dist/
+      check-manifest --verbose
       twine check dist/*
     fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This will ensure that all the build dependencies are present at build time.