### PR TITLE
Calculate CT using pressure instead of depth

### DIFF
--- a/argopy/xarray.py
+++ b/argopy/xarray.py
@@ -727,14 +727,11 @@ class ArgoAccessor:
         # Coriolis
         f = gsw.f(lat)
 
-        # Depth:
-        depth = gsw.z_from_p(pres, lat)
-
         # Absolute salinity
         sa = gsw.SA_from_SP(psal, pres, lon, lat)
 
         # Conservative temperature
-        ct = gsw.CT_from_t(sa, temp, depth)
+        ct = gsw.CT_from_t(sa, temp, pres)
 
         # Potential Temperature
         if 'PTEMP' in vlist:


### PR DESCRIPTION
This PR changes the last argument of `gsw.CT_from_t` to use pressure instead of depth for calculating conservative temperature in the xarray accessor.

Addresses the bug noted in #72