### PR TITLE
Use CF Standard Names for standard_name attribute

### DIFF
--- a/argopy/xarray.py
+++ b/argopy/xarray.py
@@ -765,38 +765,41 @@ class ArgoAccessor:
         that = []
         if 'SA' in vlist:
             SA = xr.DataArray(sa, coords=this['PSAL'].coords, name='SA')
-            SA.attrs['standard_name'] = 'Absolute Salinity'
+            SA.attrs['long_name'] = 'Absolute Salinity'
+            SA.attrs['standard_name'] = 'sea_water_absolute_salinity'
             SA.attrs['unit'] = 'g/kg'
             that.append(SA)
 
         if 'CT' in vlist:
             CT = xr.DataArray(ct, coords=this['TEMP'].coords, name='CT')
-            CT.attrs['standard_name'] = 'Conservative Temperature'
+            CT.attrs['long_name'] = 'Conservative Temperature'
+            CT.attrs['standard_name'] = 'sea_water_conservative_temperature'
             CT.attrs['unit'] = 'degC'
             that.append(CT)
 
         if 'SIG0' in vlist:
             SIG0 = xr.DataArray(sig0, coords=this['TEMP'].coords, name='SIG0')
             SIG0.attrs['long_name'] = 'Potential density anomaly with reference pressure of 0 dbar'
-            SIG0.attrs['standard_name'] = 'Potential Density'
+            SIG0.attrs['standard_name'] = 'sea_water_sigma_theta'
             SIG0.attrs['unit'] = 'kg/m^3'
             that.append(SIG0)
 
         if 'N2' in vlist:
             N2 = xr.DataArray(n2, coords=this['TEMP'].coords, name='N2')
-            N2.attrs['standard_name'] = 'Squared buoyancy frequency'
+            N2.attrs['long_name'] = 'Squared buoyancy frequency'
             N2.attrs['unit'] = '1/s^2'
             that.append(N2)
 
         if 'PV' in vlist:
             PV = xr.DataArray(pv, coords=this['TEMP'].coords, name='PV')
-            PV.attrs['standard_name'] = 'Planetary Potential Vorticity'
+            PV.attrs['long_name'] = 'Planetary Potential Vorticity'
             PV.attrs['unit'] = '1/m/s'
             that.append(PV)
 
         if 'PTEMP' in vlist:
             PTEMP = xr.DataArray(pt, coords=this['TEMP'].coords, name='PTEMP')
-            PTEMP.attrs['standard_name'] = 'Potential Temperature'
+            PTEMP.attrs['long_name'] = 'Potential Temperature'
+            PTEMP.attrs['standard_name'] = 'sea_water_potential_temperature'
             PTEMP.attrs['unit'] = 'degC'
             that.append(PTEMP)
 

--- a/argopy/xarray.py
+++ b/argopy/xarray.py
@@ -709,6 +709,10 @@ class ArgoAccessor:
             raise ModuleNotFoundError(
                 "This functionality requires the gsw library")
 
+        allowed = ['SA', 'CT', 'SIG0', 'N2', 'PV', 'PTEMP']
+        if any(var not in allowed for var in vlist):
+            raise ValueError(f"vlist must be a subset of {allowed}, instead found {vlist}")
+
         this = self._obj
 
         to_profile = False

--- a/argopy/xarray.py
+++ b/argopy/xarray.py
@@ -690,13 +690,33 @@ class ArgoAccessor:
     def teos10(self, vlist: list = ['SA', 'CT', 'SIG0', 'N2', 'PV', 'PTEMP'], inplace: bool = True):
         """ Add TEOS10 variables to the dataset
 
-        By default, add: 'SA', 'CT', 'SIG0', 'N2', 'PV', 'PTEMP'
-        Rely on the gsw library.
+        By default, adds: 'SA', 'CT', 'SIG0', 'N2', 'PV', 'PTEMP'
+        Relies on the gsw library.
+
+        If one exists, the correct CF standard name will be added to the attrs.
 
         Parameters
         ----------
         vlist: list(str)
             List with the name of variables to add.
+            Must be a list containing one or more of the following string values:
+
+            * `"SA"`
+                Adds an absolute salinity variable
+            * `"CT"`
+                Adds a conservative temperature variable
+            * `"SIG0"`
+                Adds a potential density anomaly variable referenced to 0 dbar
+            * `"N2"`
+                Adds a buoyancy (Brunt-Vaisala) frequency squared variable.
+                This variable has been regridded to the original pressure levels in the Dataset using a linear interpolation.
+            * `"PV"`
+                Adds a planetary vorticity variable calculated from :math:`\\frac{f N^2}{\\text{gravity}}`.
+                This is not a TEOS-10 variable from the gsw toolbox, but is provided for convenience.
+                This variable has been regridded to the original pressure levels in the Dataset using a linear interpolation.
+            * `"PTEMP"`
+                Adds a potential temperature variable
+            
         inplace: boolean, True by default
             If True, return the input :class:`xarray.Dataset` with new TEOS10 variables added as a new :class:`xarray.DataArray`
             If False, return a :class:`xarray.Dataset` with new TEOS10 variables

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -32,6 +32,10 @@ v0.1.7 (XX Nov. 2020)
 
 **Breaking changes with previous versions**
 
+- In the teos10 xarray accessor, the ``standard_name`` attribute will now be populated using values from the `CF Standard Name table <https://cfconventions.org/Data/cf-standard-names/76/build/cf-standard-name-table.html>`_ if one exists.
+  The previous values of ``standard_name`` have been moved to the ``long_name`` attribute.
+  (:pr:`74`) by `A. Barna <https://github.com/docotak>`_.
+  
 - The unique resource identifier property is now named ``uri`` for all data fetchers, it is always a list of strings.
 
 **Internals**


### PR DESCRIPTION
In the xarray accessor calculating teos10 params, this will set the `standard_name` attribute of the created variable to the correct name from the [CF Standard Name table](http://cfconventions.org/Data/cf-standard-names/76/build/cf-standard-name-table.html) if one exists.

Currently the "Squared buoyancy frequency" lacks a standard name.

The possible standard name for "Planetary Potential Vorticity" is potential_vorticity_of_ocean_layer, but this is way outside my knowledge.

This PR moves the existing `standard_name` to the `long_name` attribute