### PR TITLE
Remove upper bound on all dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-xarray>=0.15.1, <2022.3.1
-scipy>=1.1.0, <1.8.1
-scikit-learn<2.0, >=0.21
-netCDF4<1.5.9, >=1.3.1
-dask>=2.9, <2022.2.2
-toolz>=0.8.2, <0.11.3
-erddapy>=0.6, <1.2.1
-fsspec>=0.7.4, <2022.3.0
-gsw<=3.4.0, >=3.3.1
-aiohttp>=3.6.2, <3.8.2
-packaging>= 20.4, < 22.0
+xarray>=0.15.1
+scipy>=1.1.0
+scikit-learn<2.0
+netCDF4<1.5.9
+dask>=2.9
+toolz>=0.8.2
+erddapy>=0.6
+fsspec>=0.7.4
+gsw<=3.4.0
+aiohttp>=3.6.2
+packaging>= 20.4


### PR DESCRIPTION
Argopy is the only package I know of which pins an upper bound version for all of its dependencies.

In general, upstream packages will not do things that are backwards incompatible with their current version, at least not without a long deprecation cycle that will generate lots of warnings. So it is safe to not specify and upper bound on your dependencies.

Doing this will make argopy much easier to install.