### PR TITLE
New dashboard for profiles & profiles ID in Coriolis DB 

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -21,6 +21,15 @@ What's New
 v0.1.11 (X XXX. 2022)
 ---------------------
 
+**Features and front-end API**
+
+- **New dashboard for profiles**. Calling on the data fetcher dashboard method will return the Euro-Argo profile page for a single profile.
+
+.. code-block:: python
+
+    from argopy import DataFetcher as ArgoDataFetcher
+    ArgoDataFetcher().profile(6902755, 11).dashboard()
+
 **Internals**
 
 - Fix bug in erddap fata fetcher that was causing a `profile` request to do not account for cycle numbers. (:commit:`301e557fdec1f2d536841464b383edc3a4c4a62d`) by `G. Maze <http://www.github.com/gmaze>`_.


### PR DESCRIPTION
Using the "trajectory" entry point of the https://dataselection.euro-argo.eu/ API, it now comes easy to get the Coriolis ID of a given Argo profiles.
This PR implements an easy access to this information through misc functions and methods.

```python
from argopy import DataFetcher as ArgoDataFetcher
ArgoDataFetcher().profile(6902755, 11).dashboard()
```
Will insert this page this page in a notebook: https://dataselection.euro-argo.eu/cycle/4466214

the function ``plotters.get_coriolis_profile_id`` can be used to return the list of profile pages:
```python
from argopy.plotters import get_coriolis_profile_id
ArgoSet = ArgoDataFetcher().profile(6902755, [11, 12])
get_coriolis_profile_id(ArgoSet.fetcher.WMO, ArgoSet.fetcher.CYC)
```
