### PR TITLE
Remove dependency to sklearn

### DIFF
--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -35,7 +35,7 @@ jobs:
   pinned:
     # CI tests for pinned environments, argopy must pass tests in a controlled environment
 
-    name: Env. all pinned - Py ${{matrix.python-version}} - ${{ matrix.os }}
+    name: All pinned - Py ${{matrix.python-version}} - ${{ matrix.os }}
     needs: detect-ci-trigger
     runs-on: ${{ matrix.os }}
     if: needs.detect-ci-trigger.outputs.triggered == 'false'
@@ -108,7 +108,7 @@ jobs:
 
   min:
 
-    name: Env. all minimum - Py ${{matrix.python-version}} - ${{ matrix.os }}
+    name: All minimum - Py ${{matrix.python-version}} - ${{ matrix.os }}
     needs: detect-ci-trigger
     runs-on: ${{ matrix.os }}
     if: needs.detect-ci-trigger.outputs.triggered == 'false'
@@ -175,7 +175,7 @@ jobs:
 
   free-core:
 
-    name: Env. core free - Py ${{matrix.python-version}} - ${{ matrix.os }}
+    name: Core free - Py ${{matrix.python-version}} - ${{ matrix.os }}
     needs: detect-ci-trigger
     runs-on: ${{ matrix.os }}
     if: needs.detect-ci-trigger.outputs.triggered == 'false'
@@ -242,7 +242,7 @@ jobs:
 
   free-all:
 
-    name: Env. all free - Py ${{matrix.python-version}} - ${{ matrix.os }}
+    name: All free - Py ${{matrix.python-version}} - ${{ matrix.os }}
     needs: free-core
     runs-on: ${{ matrix.os }}
     if: needs.detect-ci-trigger.outputs.triggered == 'false'

--- a/argopy/utilities.py
+++ b/argopy/utilities.py
@@ -570,7 +570,6 @@ def show_versions(file=sys.stdout, conda=False):  # noqa: C901
             ("xarray", lambda mod: mod.__version__),
             ("scipy", lambda mod: mod.__version__),
             ("netCDF4", lambda mod: mod.__version__),
-            ("sklearn", lambda mod: mod.__version__),  # Using 'preprocessing.LabelEncoder()' in xarray accessor, used by filters
             ("erddapy", lambda mod: mod.__version__),  # This could go away from requirements ?
             ("fsspec", lambda mod: mod.__version__),
             ("aiohttp", lambda mod: mod.__version__),
@@ -605,6 +604,7 @@ def show_versions(file=sys.stdout, conda=False):  # noqa: C901
 
             ("numpy", lambda mod: mod.__version__),  # will come with xarray and pandas
             ("pandas", lambda mod: mod.__version__),  # will come with xarray
+            ("sklearn", lambda mod: mod.__version__),
 
             ("pip", lambda mod: mod.__version__),
             ("pytest", lambda mod: mod.__version__),  # will come with pandas

--- a/argopy/xarray.py
+++ b/argopy/xarray.py
@@ -5,7 +5,6 @@ import warnings
 import numpy as np
 import pandas as pd
 import xarray as xr
-from sklearn import preprocessing  #todo: reduce requirements, can't we replace preprocessing.LabelEncoder() ?
 import logging
 
 try:
@@ -404,16 +403,21 @@ class ArgoAccessor:
         >>> wmo, cyc, drc = uid(unique_float_profile_id) # Decode
 
         """
-        le = preprocessing.LabelEncoder()
-        le.fit(["A", "D"])
-
         def encode_direction(x):
-            y = 1 - le.transform(x)
-            return np.where(y == 0, -1, y)
+            y = np.where(x=='A', 1, x)
+            y = np.where(y=='D', -1, y)
+            try:
+                return y.astype(int)
+            except ValueError:
+                raise ValueError('x has un-expected values')
 
         def decode_direction(x):
-            y = 1 - np.where(x == -1, 0, x)
-            return le.inverse_transform(y)
+            x = np.array(x)
+            if np.any(np.unique(np.abs(x)) != 1):
+                raise ValueError('x has un-expected values')
+            y = np.where(x==1, 'A', x)
+            y = np.where(y=='-1', 'D', y)
+            return y.astype('<U1')
 
         offset = 1e5
 

--- a/ci/requirements/py3.7-all-free.yml
+++ b/ci/requirements/py3.7-all-free.yml
@@ -6,7 +6,6 @@ dependencies:
   - xarray
   - scipy
   - netcdf4
-  - scikit-learn
   - erddapy
   - fsspec
   - aiohttp

--- a/ci/requirements/py3.7-all-min.yml
+++ b/ci/requirements/py3.7-all-min.yml
@@ -6,7 +6,6 @@ dependencies:
   - xarray=0.16
   - scipy=1.5
   - netcdf4=1.5.3
-  - scikit-learn=0.23
   - erddapy=0.7
   - fsspec=0.8
   - aiohttp=3.7

--- a/ci/requirements/py3.7-all-pinned.yml
+++ b/ci/requirements/py3.7-all-pinned.yml
@@ -9,7 +9,6 @@ dependencies:
   - netcdf4=1.5.8
   - packaging=21.3
   - scipy=1.7.3
-  - scikit-learn=1.0.2
   - toolz=0.11.2
   - xarray=0.20.2
 

--- a/ci/requirements/py3.7-core-free.yml
+++ b/ci/requirements/py3.7-core-free.yml
@@ -6,7 +6,6 @@ dependencies:
   - xarray
   - scipy
   - netcdf4
-  - scikit-learn
   - erddapy
   - fsspec
   - aiohttp

--- a/ci/requirements/py3.8-all-free.yml
+++ b/ci/requirements/py3.8-all-free.yml
@@ -6,7 +6,6 @@ dependencies:
   - xarray
   - scipy
   - netCDF4
-  - scikit-learn
   - erddapy
   - fsspec
   - aiohttp

--- a/ci/requirements/py3.8-all-min.yml
+++ b/ci/requirements/py3.8-all-min.yml
@@ -6,7 +6,6 @@ dependencies:
   - xarray=0.16
   - scipy=1.5
   - netcdf4=1.5.3
-  - scikit-learn=0.23
   - erddapy=0.7
   - fsspec=0.8
   - aiohttp=3.7

--- a/ci/requirements/py3.8-all-pinned.yml
+++ b/ci/requirements/py3.8-all-pinned.yml
@@ -9,7 +9,6 @@ dependencies:
   - netcdf4=1.5.8
   - packaging=21.3
   - scipy=1.8.0
-  - scikit-learn=1.1.0
   - toolz=0.11.2
   - xarray=2022.3.0
 

--- a/ci/requirements/py3.8-core-free.yml
+++ b/ci/requirements/py3.8-core-free.yml
@@ -6,7 +6,6 @@ dependencies:
   - xarray
   - scipy
   - netCDF4
-  - scikit-learn
   - erddapy
   - fsspec
   - aiohttp

--- a/ci/requirements/py3.8-core-min.yml
+++ b/ci/requirements/py3.8-core-min.yml
@@ -6,7 +6,6 @@ dependencies:
   - xarray=0.16
   - scipy=1.5
   - netcdf4=1.5.3
-  - scikit-learn=0.23
   - erddapy=0.7
   - fsspec=0.8
   - aiohttp=3.7

--- a/ci/requirements/py3.8-docs.yml
+++ b/ci/requirements/py3.8-docs.yml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.8
   - xarray
   - scipy
-  - scikit-learn
   - netcdf4
   - dask
   - toolz

--- a/ci/requirements/py3.9-all-free.yml
+++ b/ci/requirements/py3.9-all-free.yml
@@ -6,7 +6,6 @@ dependencies:
   - xarray
   - scipy
   - netCDF4
-  - scikit-learn
   - erddapy
   - fsspec
   - aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,8 @@
 xarray>=0.16
 scipy>=1.5
-scikit-learn>=0.23 #<2.0   # Using 'preprocessing.LabelEncoder()' in xarray accessor, used by filters
 netCDF4>=1.5.3 #<1.5.9
-# dask>=2.3  # This could go away ?
 toolz>=0.8.2
 erddapy>=0.7  # This could go away in the future
 fsspec>=0.8
-# gsw<=3.4.0  # Used by xarray accessor to compute new variables, so not necessary to core functionalities
 aiohttp>=3.7
 packaging>=20.4  # Using 'version' to make API compatible with several fsspec releases


### PR DESCRIPTION
Since the sklearn requirements is for Labelencoder that is only used to encode profiles direction labels 'A'/'D' into 1/-1, this dependency could easily be removed !