### PR TITLE
Export index search results to Argo-like index files

### DIFF
--- a/argopy/stores/argo_index_pa.py
+++ b/argopy/stores/argo_index_pa.py
@@ -403,7 +403,7 @@ class indexstore_pyarrow(ArgoIndexStoreProto):
         return self
 
     def to_indexfile(self, file):
-        """
+        """Save search result on file like an index profile
 
         Parameters
         ----------
@@ -427,26 +427,8 @@ class indexstore_pyarrow(ArgoIndexStoreProto):
         s = s.set_column(1, "date", new_date)
         s = s.set_column(7, "date_update", new_date_update)
 
-        def insert_header(originalfile):
-            header = """# Title : Profile directory file of the Argo Global Data Assembly Center
-# Description : The directory file describes all individual profile files of the argo GDAC ftp site.
-# Project : ARGO
-# Format version : 2.0
-# Date of update : %s
-# FTP root number 1 : ftp://ftp.ifremer.fr/ifremer/argo/dac
-# FTP root number 2 : ftp://usgodae.org/pub/outgoing/argo/dac
-# GDAC node : CORIOLIS
-file,date,latitude,longitude,ocean,profiler_type,institution,date_update
-""" % pd.to_datetime('now', utc=True).strftime('%Y%m%d%H%M%S')
-            with open(originalfile, 'r') as f:
-                with open('newfile.txt', 'w') as f2:
-                    f2.write(header)
-                    f2.write(f.read())
-            os.remove(originalfile)
-            os.rename('newfile.txt', originalfile)
-
         write_options = csv.WriteOptions(delimiter=",", include_header=False, quoting_style="none")
         csv.write_csv(s, file, write_options=write_options)
-        insert_header(file)
+        file = self._insert_header(file)
 
         return file

--- a/argopy/stores/argo_index_pa.py
+++ b/argopy/stores/argo_index_pa.py
@@ -4,6 +4,7 @@ Argo file index store
 Implementation based on pyarrow
 """
 
+import os
 import numpy as np
 import pandas as pd
 import logging
@@ -400,3 +401,52 @@ class indexstore_pyarrow(ArgoIndexStoreProto):
         self.search_filter = self._reduce_a_filter_list(filt, op='and')
         self.run(nrows=nrows)
         return self
+
+    def to_indexfile(self, file):
+        """
+
+        Parameters
+        ----------
+        file: str
+            File path to write search results to
+
+        Returns
+        -------
+        str
+        """
+        def convert_a_date(row):
+            try:
+                return row.strftime('%Y%m%d%H%M%S')
+            except:
+                return ""
+
+        new_date = pa.array(self.search['date'].to_pandas().apply(convert_a_date))
+        new_date_update = pa.array(self.search['date_update'].to_pandas().apply(convert_a_date))
+
+        s = self.search
+        s = s.set_column(1, "date", new_date)
+        s = s.set_column(7, "date_update", new_date_update)
+
+        def insert_header(originalfile):
+            header = """# Title : Profile directory file of the Argo Global Data Assembly Center
+# Description : The directory file describes all individual profile files of the argo GDAC ftp site.
+# Project : ARGO
+# Format version : 2.0
+# Date of update : %s
+# FTP root number 1 : ftp://ftp.ifremer.fr/ifremer/argo/dac
+# FTP root number 2 : ftp://usgodae.org/pub/outgoing/argo/dac
+# GDAC node : CORIOLIS
+file,date,latitude,longitude,ocean,profiler_type,institution,date_update
+""" % pd.to_datetime('now', utc=True).strftime('%Y%m%d%H%M%S')
+            with open(originalfile, 'r') as f:
+                with open('newfile.txt', 'w') as f2:
+                    f2.write(header)
+                    f2.write(f.read())
+            os.remove(originalfile)
+            os.rename('newfile.txt', originalfile)
+
+        write_options = csv.WriteOptions(delimiter=",", include_header=False, quoting_style="none")
+        csv.write_csv(s, file, write_options=write_options)
+        insert_header(file)
+
+        return file

--- a/argopy/stores/argo_index_pd.py
+++ b/argopy/stores/argo_index_pd.py
@@ -324,3 +324,24 @@ class indexstore_pandas(ArgoIndexStoreProto):
         self.search_filter = np.logical_and.reduce(filt)
         self.run(nrows=nrows)
         return self
+
+    def to_indexfile(self, outputfile):
+        """Save search result on file like an index profile
+
+        Parameters
+        ----------
+        file: str
+            File path to write search results to
+
+        Returns
+        -------
+        str
+        """
+
+        self.search.to_csv(outputfile, sep=',', index=False, index_label=False,
+                      header=False,
+                      columns=['file', 'date', 'latitude', 'longitude', 'ocean', 'profiler_type', 'institution',
+                               'date_update'])
+        outputfile = self._insert_header(outputfile)
+
+        return outputfile

--- a/argopy/stores/argo_index_proto.py
+++ b/argopy/stores/argo_index_proto.py
@@ -493,7 +493,6 @@ class ArgoIndexStoreProto(ABC):
 
         return df
 
-    @abstractmethod
     def to_indexfile(self):
         """Save search results on file, following the Argo standard index formats"""
         raise NotImplementedError("Not implemented")

--- a/argopy/stores/argo_index_proto.py
+++ b/argopy/stores/argo_index_proto.py
@@ -3,6 +3,7 @@ Argo file index store prototype
 
 """
 
+import os
 import numpy as np
 import pandas as pd
 import logging
@@ -701,3 +702,22 @@ class ArgoIndexStoreProto(ABC):
 
         """
         raise NotImplementedError("Not implemented")
+
+    def _insert_header(self, originalfile):
+        header = """# Title : Profile directory file of the Argo Global Data Assembly Center
+# Description : The directory file describes all individual profile files of the argo GDAC ftp site.
+# Project : ARGO
+# Format version : 2.0
+# Date of update : %s
+# FTP root number 1 : ftp://ftp.ifremer.fr/ifremer/argo/dac
+# FTP root number 2 : ftp://usgodae.org/pub/outgoing/argo/dac
+# GDAC node : CORIOLIS
+file,date,latitude,longitude,ocean,profiler_type,institution,date_update
+""" % pd.to_datetime('now', utc=True).strftime('%Y%m%d%H%M%S')
+        with open(originalfile, 'r') as f:
+            with open('newfile.txt', 'w') as f2:
+                f2.write(header)
+                f2.write(f.read())
+        os.remove(originalfile)
+        os.rename('newfile.txt', originalfile)
+        return originalfile

--- a/argopy/stores/argo_index_proto.py
+++ b/argopy/stores/argo_index_proto.py
@@ -716,10 +716,10 @@ file,date,latitude,longitude,ocean,profiler_type,institution,date_update
 """ % pd.to_datetime('now', utc=True).strftime('%Y%m%d%H%M%S')
 
         with open(originalfile, 'r') as f:
-            with open('newfile.txt', 'w') as f2:
-                f2.write(header)
-                f2.write(f.read())
-        f.close()
-        os.remove(originalfile)
-        os.rename('newfile.txt', originalfile)
+            data = f.read()
+
+        with open(originalfile, 'w') as f:
+            f.write(header)
+            f.write(data)
+
         return originalfile

--- a/argopy/stores/argo_index_proto.py
+++ b/argopy/stores/argo_index_proto.py
@@ -493,6 +493,11 @@ class ArgoIndexStoreProto(ABC):
 
         return df
 
+    @abstractmethod
+    def to_indexfile(self):
+        """Save search results on file, following the Argo standard index formats"""
+        raise NotImplementedError("Not implemented")
+
     @property
     @abstractmethod
     def search_path(self):

--- a/argopy/stores/argo_index_proto.py
+++ b/argopy/stores/argo_index_proto.py
@@ -714,10 +714,12 @@ class ArgoIndexStoreProto(ABC):
 # GDAC node : CORIOLIS
 file,date,latitude,longitude,ocean,profiler_type,institution,date_update
 """ % pd.to_datetime('now', utc=True).strftime('%Y%m%d%H%M%S')
+
         with open(originalfile, 'r') as f:
             with open('newfile.txt', 'w') as f2:
                 f2.write(header)
                 f2.write(f.read())
+        f.close()
         os.remove(originalfile)
         os.rename('newfile.txt', originalfile)
         return originalfile

--- a/argopy/tests/test_stores.py
+++ b/argopy/tests/test_stores.py
@@ -905,13 +905,16 @@ class IndexStore_test_proto:
         wmo = [s['wmo'] for s in VALID_SEARCHES if 'wmo' in s.keys()][0]
         idx = idx.search_wmo(wmo)
 
-        # Then save this search as new Argo index file:
-        tf = tempfile.NamedTemporaryFile(delete=True)
+        # Then save this search as a new Argo index file:
+        tf = tempfile.NamedTemporaryFile(delete=True, mode='w')
         new_indexfile = idx.to_indexfile(tf.name)
 
-        # Test succeeds if we can load this new index, like it was an official one:
+        # Finally try to load the new index file, like it was an official one:
         idx = self.new_idx(host=os.path.dirname(new_indexfile), index_file=os.path.basename(new_indexfile))
         self.assert_index(idx.load())
+
+        # Cleanup
+        tf.close()
 
 
 @skip_this

--- a/argopy/tests/test_stores.py
+++ b/argopy/tests/test_stores.py
@@ -899,18 +899,6 @@ class IndexStore_test_proto:
         for w in C:
             assert str(C[w]).isdigit()
 
-
-@skip_this
-class Test_IndexStore_pandas(IndexStore_test_proto):
-    indexstore = indexstore_pandas
-
-
-@skip_this
-@skip_pyarrow
-class Test_IndexStore_pyarrow(IndexStore_test_proto):
-    from argopy.stores.argo_index_pa import indexstore_pyarrow
-    indexstore = indexstore_pyarrow
-
     def test_to_indexfile(self):
         # Create a store and make a simple float search:
         idx = self.new_idx()
@@ -924,3 +912,15 @@ class Test_IndexStore_pyarrow(IndexStore_test_proto):
         # Test succeeds if we can load this new index, like it was an official one:
         idx = self.new_idx(host=os.path.dirname(new_indexfile), index_file=os.path.basename(new_indexfile))
         self.assert_index(idx.load())
+
+
+@skip_this
+class Test_IndexStore_pandas(IndexStore_test_proto):
+    indexstore = indexstore_pandas
+
+
+@skip_this
+@skip_pyarrow
+class Test_IndexStore_pyarrow(IndexStore_test_proto):
+    from argopy.stores.argo_index_pa import indexstore_pyarrow
+    indexstore = indexstore_pyarrow

--- a/argopy/tests/test_stores.py
+++ b/argopy/tests/test_stores.py
@@ -906,7 +906,7 @@ class IndexStore_test_proto:
         idx = idx.search_wmo(wmo)
 
         # Then save this search as a new Argo index file:
-        tf = tempfile.NamedTemporaryFile(delete=True, mode='w')
+        tf = tempfile.NamedTemporaryFile(delete=False)
         new_indexfile = idx.to_indexfile(tf.name)
 
         # Finally try to load the new index file, like it was an official one:

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -23,7 +23,7 @@ v0.1.14 (XX Xxx. 2023)
         f = CTDRefDataFetcher(box=[15, 30, -70, -60, 0, 5000.0])
         ds = f.to_xarray()
 
-- Index store can now export search results to standard Argo index files
+- Index store can now export search results to standard Argo index files. (pr:`260`) by `G. Maze <http://www.github.com/gmaze>`_
 
 **Internals**
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -23,6 +23,8 @@ v0.1.14 (XX Xxx. 2023)
         f = CTDRefDataFetcher(box=[15, 30, -70, -60, 0, 5000.0])
         ds = f.to_xarray()
 
+- Index store can now export search results to standard Argo index files
+
 **Internals**
 
 - Use a mocked server for all http and GDAC ftp requests in CI tests (:pr:`249`, :pr:`252`, :pr:`255`) by `G. Maze <http://www.github.com/gmaze>`_


### PR DESCRIPTION
It may be useful to be able to export index search results to Argo-like index files in some local data management tasks.