### PR TITLE
pep517 is deprecated in liue of build

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -20,12 +20,11 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies with pip
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine pep517
+        python -m pip install --upgrade pip twine build
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python -m pep517.build --source --binary . --out-dir dist
+        python -m build --sdist --wheel . --outdir dist/
         twine upload --skip-existing dist/*


### PR DESCRIPTION
The pep517 package is also used in the `.travis.yml` but I guess that one is no longer used, right?