### PR TITLE
Fix bug with GDAC data source and BGC dataset

### DIFF
--- a/argopy/data_fetchers/gdac_data_processors.py
+++ b/argopy/data_fetchers/gdac_data_processors.py
@@ -1,5 +1,9 @@
 import numpy as np
 import xarray as xr
+import logging
+
+
+log = logging.getLogger("argopy.gdac.data")
 
 
 def pre_process_multiprof(

--- a/argopy/extensions/params_data_mode.py
+++ b/argopy/extensions/params_data_mode.py
@@ -43,7 +43,7 @@ class ParamsDataMode(ArgoAccessorExtension):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _infer_from_ArgoIndex(self, indexfs: Union[None, ArgoIndex]) -> xr.Dataset:  # noqa: C901
+    def _compute_from_ArgoIndex(self, indexfs: Union[None, ArgoIndex]) -> xr.Dataset:  # noqa: C901
         """Compute <PARAM>_DATA_MODE variables from ArgoIndex
 
         This method consumes a collection of points.
@@ -174,7 +174,7 @@ class ParamsDataMode(ArgoAccessorExtension):
         if "STATION_PARAMETERS" in self._obj and "PARAMETER_DATA_MODE" in self._obj:
             return split_data_mode(self._obj)
         else:
-            return self._infer_from_ArgoIndex(indexfs=indexfs)
+            return self._compute_from_ArgoIndex(indexfs=indexfs)
 
     def split(self):
         return split_data_mode(self._obj)

--- a/argopy/extensions/params_data_mode.py
+++ b/argopy/extensions/params_data_mode.py
@@ -6,7 +6,11 @@ from typing import Union, List
 import copy
 
 from ..utils import to_list, list_core_parameters
-from ..utils.transform import split_data_mode, merge_param_with_param_adjusted, filter_param_by_data_mode
+from ..utils.transform import (
+    split_data_mode,
+    merge_param_with_param_adjusted,
+    filter_param_by_data_mode,
+)
 from ..stores import (
     indexstore_pd as ArgoIndex,
 )  # make sure we work with a Pandas index store
@@ -25,10 +29,10 @@ class ParamsDataMode(ArgoAccessorExtension):
 
     See Also
     --------
-    :meth:`datamode.compute` # Compute <PARAM>_DATA_MODE(N_PROF)
-    :meth:`datamode.merge`   # Merge <PARAM> and <PARAM>_ADJUSTED variables according to DATA_MODE or <PARAM>_DATA_MODE
+    :meth:`datamode.compute`
+    :meth:`datamode.merge`
     :meth:`datamode.filter`
-    :meth:`datamode.split`   # Split PARAMETER_DATA_MODE(N_PROF, N_PARAM) into several <PARAM>_DATA_MODE(N_PROF)
+    :meth:`datamode.split`
 
     Examples
     --------
@@ -43,7 +47,9 @@ class ParamsDataMode(ArgoAccessorExtension):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _compute_from_ArgoIndex(self, indexfs: Union[None, ArgoIndex]) -> xr.Dataset:  # noqa: C901
+    def _compute_from_ArgoIndex(
+        self, indexfs: Union[None, ArgoIndex]
+    ) -> xr.Dataset:  # noqa: C901
         """Compute <PARAM>_DATA_MODE variables from ArgoIndex
 
         This method consumes a collection of points.
@@ -55,7 +61,7 @@ class ParamsDataMode(ArgoAccessorExtension):
 
         Returns
         -------
-        :class:`xr.Dataset`
+        :class:`xarray.Dataset`
         """
         idx = indexfs.copy(deep=True) if isinstance(indexfs, ArgoIndex) else ArgoIndex()
 
@@ -176,10 +182,23 @@ class ParamsDataMode(ArgoAccessorExtension):
         else:
             return self._compute_from_ArgoIndex(indexfs=indexfs)
 
-    def split(self):
+    def split(self) -> xr.Dataset:
+        """Convert PARAMETER_DATA_MODE(N_PROF, N_PARAM) into several <PARAM>_DATA_MODE(N_PROF) variables
+
+        Using the list of *PARAM* found in ``STATION_PARAMETERS``, this method will create ``N_PARAM``
+        new variables in the dataset ``<PARAM>_DATA_MODE(N_PROF)``.
+
+        The variable ``PARAMETER_DATA_MODE`` is drop from the dataset at the end of the process.
+
+        Returns
+        -------
+        :class:`xarray.Dataset`
+        """
         return split_data_mode(self._obj)
 
-    def merge(self, params: Union[str, List[str]] = "all", errors: str = "raise") -> xr.Dataset:
+    def merge(
+        self, params: Union[str, List[str]] = "all", errors: str = "raise"
+    ) -> xr.Dataset:
         """Merge <PARAM> and <PARAM>_ADJUSTED variables according to DATA_MODE or <PARAM>_DATA_MODE
 
         Merging is done as follows:
@@ -259,7 +278,7 @@ class ParamsDataMode(ArgoAccessorExtension):
         logical: str = "and",
         mask: bool = False,
         errors: str = "raise",
-    ):
+    ) -> xr.Dataset:
         """Filter measurements according to parameters data mode
 
         Filter the dataset to keep points where all or some of the parameters are in any of the data mode specified.

--- a/argopy/fetchers.py
+++ b/argopy/fetchers.py
@@ -177,6 +177,8 @@ class ArgoDataFetcher:
             raise OptionValueError(
                 "The 'argovis' data source fetching is only available in 'standard' user mode"
             )
+        if self._src == "gdac" and "bgc" in self._dataset_id:
+            warnings.warn("BGC data support with the 'gdac' data source is still in Work In Progress")
 
     @property
     def _icon_user_mode(self):

--- a/argopy/stores/argo_index_proto.py
+++ b/argopy/stores/argo_index_proto.py
@@ -162,7 +162,7 @@ class ArgoIndexStoreProto(ABC):
                 port=0 if urlparse(host).port is None else urlparse(host).port,
                 cache=cache,
                 cachedir=cachedir,
-                timeout=timeout,
+                timeout=self.timeout,
                 block_size=1000 * (2**20),
             )
 

--- a/argopy/utils/transform.py
+++ b/argopy/utils/transform.py
@@ -361,15 +361,18 @@ def split_data_mode(ds: xr.Dataset) -> xr.Dataset:
             name = "%s_DATA_MODE" % param.replace("_PARAMETER", "").replace(
                 "PARAMETER_", ""
             )
-            mask = ds["STATION_PARAMETERS"] == xr.full_like(
-                ds["STATION_PARAMETERS"],
-                u64(param),
-                dtype=ds["STATION_PARAMETERS"].dtype,
-            )
-            da = ds["PARAMETER_DATA_MODE"].where(mask, drop=True).isel(N_PARAM=0)
-            da = da.rename(name)
-            da = da.astype(ds["PARAMETER_DATA_MODE"].dtype)
-            ds[name] = da
+            if name == "_DATA_MODE":
+                log.error("This dataset has an error in 'STATION_PARAMETERS': it contains an empty string")
+            else:
+                mask = ds["STATION_PARAMETERS"] == xr.full_like(
+                    ds["STATION_PARAMETERS"],
+                    u64(param),
+                    dtype=ds["STATION_PARAMETERS"].dtype,
+                )
+                da = ds["PARAMETER_DATA_MODE"].where(mask, drop=True).isel(N_PARAM=0)
+                da = da.rename(name)
+                da = da.astype(ds["PARAMETER_DATA_MODE"].dtype)
+                ds[name] = da
 
         ds = ds.drop_vars("PARAMETER_DATA_MODE")
         ds.argo.add_history("Transformed with 'split_data_mode'")

--- a/argopy/utils/transform.py
+++ b/argopy/utils/transform.py
@@ -354,6 +354,11 @@ def split_data_mode(ds: xr.Dataset) -> xr.Dataset:
     -------
     :class:`xr.Dataset`
     """
+    if ds.argo._type != "profile":
+        raise InvalidDatasetStructure(
+            "Method only available to a collection of profiles"
+        )
+
     if "STATION_PARAMETERS" in ds and "PARAMETER_DATA_MODE" in ds:
 
         u64 = lambda s: "%s%s" % (s, " " * (64 - len(s)))  # noqa: E731

--- a/argopy/utils/transform.py
+++ b/argopy/utils/transform.py
@@ -4,6 +4,7 @@ Manipulate/transform xarray objects or list of objects
 
 import numpy as np
 import xarray as xr
+import pandas as pd
 import logging
 from typing import List, Union
 
@@ -340,6 +341,7 @@ def filter_param_by_data_mode(
         return ds.loc[dict(N_POINTS=filter)] if len(filter) > 0 else ds
 
 
+
 def split_data_mode(ds: xr.Dataset) -> xr.Dataset:
     """Convert PARAMETER_DATA_MODE(N_PROF, N_PARAM) into several <PARAM>_DATA_MODE(N_PROF) variables
 
@@ -357,6 +359,30 @@ def split_data_mode(ds: xr.Dataset) -> xr.Dataset:
         u64 = lambda s: "%s%s" % (s, " " * (64 - len(s)))  # noqa: E731
         params = [p.strip() for p in np.unique(ds["STATION_PARAMETERS"])]
 
+        def read_data_mode_for(ds: xr.Dataset, param: str) -> xr.DataArray:
+            """Return data mode of a given parameter"""
+            da_masked = ds['PARAMETER_DATA_MODE'].where(ds['STATION_PARAMETERS'] == u64(param))
+
+            def _dropna(x):
+                # x('N_PARAM') is reduced to the first non nan value, a scalar, no dimension
+                y = pd.Series(x).dropna().tolist()
+                if len(y) == 0:
+                    return ""
+                else:
+                    return y[0]
+
+            kwargs = dict(
+                dask="parallelized",
+                input_core_dims=[["N_PARAM"]],  # Function takes N_PARAM as input
+                output_core_dims=[[]],  # Function reduces to a scalar (no dimension)
+                vectorize=True  # Apply function element-wise along the other dimensions
+            )
+
+            dm = xr.apply_ufunc(_dropna, da_masked, **kwargs)
+            dm = dm.rename("%s_DATA_MODE" % param)
+            dm.attrs = ds['PARAMETER_DATA_MODE'].attrs
+            return dm
+
         for param in params:
             name = "%s_DATA_MODE" % param.replace("_PARAMETER", "").replace(
                 "PARAMETER_", ""
@@ -364,15 +390,7 @@ def split_data_mode(ds: xr.Dataset) -> xr.Dataset:
             if name == "_DATA_MODE":
                 log.error("This dataset has an error in 'STATION_PARAMETERS': it contains an empty string")
             else:
-                mask = ds["STATION_PARAMETERS"] == xr.full_like(
-                    ds["STATION_PARAMETERS"],
-                    u64(param),
-                    dtype=ds["STATION_PARAMETERS"].dtype,
-                )
-                da = ds["PARAMETER_DATA_MODE"].where(mask, drop=True).isel(N_PARAM=0)
-                da = da.rename(name)
-                da = da.astype(ds["PARAMETER_DATA_MODE"].dtype)
-                ds[name] = da
+                ds[name] = read_data_mode_for(ds, param)
 
         ds = ds.drop_vars("PARAMETER_DATA_MODE")
         ds.argo.add_history("Transformed with 'split_data_mode'")

--- a/argopy/xarray.py
+++ b/argopy/xarray.py
@@ -402,7 +402,7 @@ class ArgoAccessor:
 
         Returns
         -------
-        :class:`xr.dataset`
+        :class:`xr.Dataset`
 
         See Also
         --------
@@ -563,9 +563,11 @@ class ArgoAccessor:
         - A "point" is a location with unique (N_PROF, N_LEVELS) indexes
         - A "profile" is a collection of points with an unique UID based on WMO, CYCLE_NUMBER and DIRECTION
 
+        Note that this method will systematically apply the :meth:`datamode.split` method.
+
         Returns
         -------
-        :class:`xr.dataset`
+        :class:`xr.Dataset`
 
         Warnings
         --------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -159,6 +159,7 @@ Data Transformation
    Dataset.argo.interp_std_levels
    Dataset.argo.groupby_pressure_bins
    Dataset.argo.datamode.merge
+   Dataset.argo.datamode.split
 
 
 Data Filters


### PR DESCRIPTION
The data mode splitting method was found to provide erroneous results due to unexpected results from xarray dropna

The `ds.argo.datamode.split` method now use a clean ufunc method to properly extract parameter data mode