### PR TITLE
For a given float WMO, a new class to easily open netcdf dataset for local and remote GDAC

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -11,6 +11,33 @@ What's New
 Coming up next
 --------------
 
+Features and front-end API
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- New **float store** to delegate to argopy all Argo netcdf files access/read methods, for local and remote GDAC content. This new data store, :class:`ArgoFloat`, aims to provide methods for third party libraries, or operator and expert workflow, to access local, or remote, Argo GDAC netcdf files without the burden of transfer protocol and GDAC paths handling.
+
+.. code-block:: python
+
+    from argopy import ArgoFloat
+    WMO = 6903091
+
+    af = ArgoFloat(WMO)  # Use argopy 'gdac' option by default
+    af = ArgoFloat(WMO, host='https')  # Shortcut for https://data-argo.ifremer.fr
+    af = ArgoFloat(WMO, host='ftp')    # shortcut for ftp://ftp.ifremer.fr/ifremer/argo
+    af = ArgoFloat(WMO, host='s3')     # Shortcut for s3://argo-gdac-sandbox/pub
+    af = ArgoFloat(WMO, host='/home/ref-argo/gdac')  # Use your local GDAC copy
+
+    # Access GDAC netcdf files content from dac folder for core-deep floats:
+    af.meta # Return xarray dataset with data from: <WMO>_meta.nc
+    af.prof # Return xarray dataset with data from: <WMO>_prof.nc
+    af.tech # Return xarray dataset with data from: <WMO>_tech.nc
+    af.Rtraj # Return xarray dataset with data from: <WMO>_Rtraj.nc
+
+    # Access GDAC netcdf files content from dac folder for BGC floats:
+    af.BRtraj # Return xarray dataset with data from: <WMO>_BRtraj.nc
+    af.Sprof # Return xarray dataset with data from: <WMO>_Sprof.nc
+
+
 Internals
 ^^^^^^^^^
 


### PR DESCRIPTION
This PR shall provides a new **float store** to delegate to argopy all Argo netcdf files access/read methods, for local and remote GDAC content. 

This new data store, `ArgoFloat`, aims to provide methods for third party libraries, or operator and expert workflow, to access local, or remote, Argo GDAC netcdf files without the burden of transfer protocol and GDAC paths handling.

Expected API:
```python
    from argopy import ArgoFloat
    WMO = 6903091

    af = ArgoFloat(WMO)  # Use argopy 'gdac' option by default
    af = ArgoFloat(WMO, host='https')  # Shortcut for https://data-argo.ifremer.fr
    af = ArgoFloat(WMO, host='ftp')    # shortcut for ftp://ftp.ifremer.fr/ifremer/argo
    af = ArgoFloat(WMO, host='s3')     # Shortcut for s3://argo-gdac-sandbox/pub
    af = ArgoFloat(WMO, host='/home/ref-argo/gdac')  # Use your local GDAC copy

    # Access GDAC netcdf files content from dac folder for core-deep floats:
    af.meta # Return xarray dataset with data from: <WMO>_meta.nc
    af.prof # Return xarray dataset with data from: <WMO>_prof.nc
    af.tech # Return xarray dataset with data from: <WMO>_tech.nc
    af.Rtraj # Return xarray dataset with data from: <WMO>_Rtraj.nc

    # Access GDAC netcdf files content from dac folder for BGC floats:
    af.BRtraj # Return xarray dataset with data from: <WMO>_BRtraj.nc
    af.Sprof # Return xarray dataset with data from: <WMO>_Sprof.nc
```

This new class shall provides much more attributess and methods. The API design is laid out in here: https://gist.github.com/gmaze/6924fc26405f42aa36fd5a22a64657ea
