### PR TITLE
gdacfs to support directory prefix

### DIFF
--- a/argopy/stores/spec.py
+++ b/argopy/stores/spec.py
@@ -57,6 +57,18 @@ class ArgoStoreProto(ABC):
     def sep(self):
         return self.fs.sep
 
+    @property
+    def async_impl(self):
+        return self.fs.async_impl
+
+    @property
+    def asynchronous(self):
+        return getattr(self.fs, 'asynchronous', False)
+
+    @property
+    def target_protocol(self):
+        return getattr(self.fs, 'target_protocol', self.protocol)
+
     def exists(self, path, *args):
         return self.fs.exists(path, *args)
 


### PR DESCRIPTION
Start over work from #424 

In this PR we provide a file system with a directory prefix for any Argo GDAC compliant path.

The goal is to be able to simply create a ``gdacfs`` instance with a GDAC path (local or remote) that won't require the GDAC path to be systematically provided to open files.

In other word, before this PR we have to do this:
```python
from argopy.stores import gdacfs
fs = gdacfs("https://data-argo.ifremer.fr")
ds = fs.open_dataset("https://data-argo.ifremer.fr/dac/coriolis/6903091/profiles/R6903091_001.nc")
# or
fs = gdacfs("https://usgodae.org/pub/outgoing/argo")
ds = fs.open_dataset("https://usgodae.org/pub/outgoing/argo/dac/coriolis/6903091/profiles/R6903091_001.nc")
```

and after the PR we will be able to do this:
```python
from argopy.stores import gdacfs
fs = gdacfs("https://data-argo.ifremer.fr")
# or
fs = gdacfs("https://usgodae.org/pub/outgoing/argo")
# then
ds = fs.open_dataset("dac/coriolis/6903091/profiles/R6903091_001.nc")
```

This is easily implemented in the current ``gdacfs`` but requires a lot of upstream compatibility check for all argopy stores implementations.

The ultimate test will be this to run ok:
```python
from argopy.stores import gdacfs
from argopy.utils import list_gdac_servers

for gdac_path in list_gdac_servers():
  fs = gdacfs(gdac_path)
  ds =  fs.open_dataset("dac/coriolis/6903091/profiles/R6903091_001.nc")
```

