### PR TITLE
Update xarray accessor to handle profile file from ArgoFloat

### DIFF
--- a/argopy/extensions/canyon_med.py
+++ b/argopy/extensions/canyon_med.py
@@ -167,9 +167,10 @@ class CanyonMED(ArgoAccessorExtension):
     @property
     def decimal_year(self):
         """Return the decimal year of the :class:`xr.Dataset` `TIME` variable"""
-        return self._obj['TIME'].dt.year + (86400 * self._obj['TIME'].dt.dayofyear
-                                            + 3600 * self._obj['TIME'].dt.hour
-                                            + self._obj['TIME'].dt.second) / (365.0 * 24 * 60 * 60)
+        time_array = self._obj[self._argo._TNAME]
+        return time_array.dt.year + (86400 * time_array.dt.dayofyear
+                                            + 3600 * time_array.dt.hour
+                                            + time_array.dt.second) / (365.0 * 24 * 60 * 60)
 
     def ds2df(self) -> pd.DataFrame:
         """Create a CANYON-MED input :class:`pd.DataFrame` from :class:`xr.Dataset`"""

--- a/argopy/extensions/canyon_med.py
+++ b/argopy/extensions/canyon_med.py
@@ -4,6 +4,7 @@ import pandas as pd
 import xarray as xr
 from typing import Union, List
 
+from ..errors import InvalidDatasetStructure, DataNotFound
 from ..utils import path2assets, to_list
 from . import register_argo_accessor, ArgoAccessorExtension
 
@@ -57,6 +58,13 @@ class CanyonMED(ArgoAccessorExtension):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        if self._argo._type != "point":
+            raise InvalidDatasetStructure(
+                "Method only available for a collection of points"
+            )
+        if self._argo.N_POINTS == 0:
+            raise DataNotFound("Empty dataset, no data to transform !")
 
         self.n_list = 5
         self.path2coef = Path(path2assets).joinpath('canyon-med')
@@ -352,6 +360,6 @@ class CanyonMED(ArgoAccessorExtension):
 
         # Return xr.Dataset with predicted variables:
         if self._argo:
-            self._argo.add_history("Added CANYON-MED predictions")
+            self._argo.add_history("Added CANYON-MED predictions for [%s]" % (",".join(params)))
 
         return self._obj

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -91,6 +91,9 @@ Internals
 
 - Fix bug raising an error when exporting a dataset to netcdf after erddap fetch, :issue:`412`. (:pr:`413`) by |gmaze|.
 
+- The :class:`Dataset.argo.canyon_med` predictor raises errors if not dealing with a collection of Argo points. (:pr:`450`) by |gmaze|.
+
+- Make the :class:`Dataset.argo` accessor and its extensions able to work with dataset from a :class:`DataFetcher` and from a :class:`ArgoFloat`. This was necessary because the time variable does not have the same name in these dataset (``TIME`` vs ``JULD``). But this point should be addressed later. (:pr:`450`) by |gmaze|.
 
 Energy
 ^^^^^^


### PR DESCRIPTION
The xarray ``argo`` accessor assumes to be working with a dataset that was post-processed by a data fetcher.

But this is not longer necessary the case because of the ``ArgoFloat`` class that can directly return a netcdf dataset.

This PR shall make the xarray ``argo`` accessor usable in any situation of a multi-profile dataset

**NOTE**

This PR highlights that argopy now exposes two methods to return Argo data, from the DataFetcher and from the ArgoFloat. 

But these methods do not have the same processing chain and return an Argo xarray dataset where the time variable does not have the same name, ``TIME`` vs ``JULD``.

This is not satisfactory in design and should be addressed in the future.

