### PR TITLE
Add nice shortcut name handling for GDAC

### DIFF
--- a/argopy/static/assets/gdac_servers.json
+++ b/argopy/static/assets/gdac_servers.json
@@ -1,14 +1,25 @@
 {
   "name": "gdac",
   "long_name": "List of official Argo GDAC servers",
-  "last_update": "2024-12-17T14:34:57.182480+00:00",
+  "last_update": "2025-03-03T14:38:30.247316+00:00",
   "data": {
-    "path": [
+    "paths": [
       "https://data-argo.ifremer.fr",
       "https://usgodae.org/pub/outgoing/argo",
       "https://argo-gdac-sandbox.s3-eu-west-3.amazonaws.com/pub",
       "ftp://ftp.ifremer.fr/ifremer/argo",
       "s3://argo-gdac-sandbox/pub"
-    ]
+    ],
+    "shortcuts": {
+      "http": "https://data-argo.ifremer.fr",
+      "https": "https://data-argo.ifremer.fr",
+      "fr-http": "https://data-argo.ifremer.fr",
+      "fr-https": "https://data-argo.ifremer.fr",
+      "us-http": "https://usgodae.org/pub/outgoing/argo",
+      "us-https": "https://usgodae.org/pub/outgoing/argo",
+      "ftp": "ftp://ftp.ifremer.fr/ifremer/argo",
+      "s3": "s3://argo-gdac-sandbox/pub",
+      "aws": "s3://argo-gdac-sandbox/pub"
+    }
   }
 }

--- a/argopy/stores/float/spec.py
+++ b/argopy/stores/float/spec.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ...errors import InvalidOption
 from ...plot import dashboard
-from ...utils import check_wmo, isconnected, argo_split_path
+from ...utils import check_wmo, isconnected, argo_split_path, shortcut2gdac
 from ...options import OPTIONS
 from .. import ArgoIndex, httpstore
 
@@ -62,7 +62,7 @@ class ArgoFloatProto(ABC):
             Time out in seconds to connect to a remote host (ftp or http).
         """
         self.WMO = check_wmo(wmo)[0]
-        self.host = OPTIONS["gdac"] if host is None else host
+        self.host = OPTIONS["gdac"] if host is None else shortcut2gdac(host)
         self.cache = bool(cache)
         self.cachedir = OPTIONS["cachedir"] if cachedir == "" else cachedir
         self.timeout = OPTIONS["api_timeout"] if timeout == 0 else timeout

--- a/argopy/stores/implementations/gdac.py
+++ b/argopy/stores/implementations/gdac.py
@@ -9,6 +9,7 @@ import fsspec
 
 from ...options import OPTIONS
 from ...errors import GdacPathError
+from ...utils.lists import shortcut2gdac
 from .. import filestore, httpstore, ftpstore, s3store
 
 
@@ -34,15 +35,25 @@ class gdacfs:
 
     Examples
     --------
+    .. code-block:: python
+        :caption: Explicit GDAC stores
 
-    >>> fs = gdacfs("https://data-argo.ifremer.fr")
-    >>> fs = gdacfs("https://usgodae.org/pub/outgoing/argo")
-    >>> fs = gdacfs("ftp://ftp.ifremer.fr/ifremer/argo")
-    >>> fs = gdacfs("/home/ref-argo/gdac")
-    >>> fs = gdacfs("s3://argo-gdac-sandbox/pub")
+        fs = gdacfs("https://data-argo.ifremer.fr")
+        fs = gdacfs("https://usgodae.org/pub/outgoing/argo")
+        fs = gdacfs("ftp://ftp.ifremer.fr/ifremer/argo")
+        fs = gdacfs("/home/ref-argo/gdac")
+        fs = gdacfs("s3://argo-gdac-sandbox/pub")
 
-    >>> with argopy.set_options(gdac="s3://argo-gdac-sandbox/pub"):
-    >>>     fs = gdacfs()
+        with argopy.set_options(gdac="s3://argo-gdac-sandbox/pub"):
+            fs = gdacfs()
+
+    .. code-block:: python
+        :caption: GDAC stores by shortcut name
+
+        fs = gdacfs("http")    # "https"    > https://data-argo.ifremer.fr
+        fs = gdacfs("us-http") # "us-https" > https://usgodae.org/pub/outgoing/argo
+        fs = gdacfs("ftp")     #            > ftp://ftp.ifremer.fr/ifremer/argo
+        fs = gdacfs("s3")      # or "aws"   > s3://argo-gdac-sandbox/pub
 
     Warnings
     --------
@@ -50,7 +61,7 @@ class gdacfs:
 
     See Also
     --------
-    :meth:`argopy.utils.check_gdac_path`, :meth:`argopy.utils.list_gdac_servers`
+    :meth:`argopy.utils.check_gdac_path`, :meth:`argopy.utils.list_gdac_servers`, :meth:`argopy.utils.shortcut2gdac`
 
     """
     protocol2fs = {"file": filestore, "http": httpstore, "ftp": ftpstore, "s3": s3store}
@@ -76,8 +87,7 @@ class gdacfs:
 
     def __new__(cls, path: Union[str, Path, None] = None, cache: bool = False, cachedir: str = "", **kwargs):
         """Create a file system for any Argo GDAC compliant path"""
-        if path is None:
-            path = OPTIONS["gdac"]
+        path = OPTIONS["gdac"] if path is None else shortcut2gdac(path)
 
         protocol = cls.path2protocol(path)
         cls.root = path

--- a/argopy/tests/test_utils_lists.py
+++ b/argopy/tests/test_utils_lists.py
@@ -1,7 +1,15 @@
-# import pytest
+import pytest
 from argopy.utils.checkers import is_list_of_strings
-from argopy.utils.lists import list_multiprofile_file_variables
+from argopy.utils.lists import list_multiprofile_file_variables, shortcut2gdac
 
 
 def test_list_multiprofile_file_variables():
     assert is_list_of_strings(list_multiprofile_file_variables())
+
+shortcuts = {None: dict, 'ftp': str, 'https://data-argo.ifremer.fr': str}
+
+@pytest.mark.parametrize("short", shortcuts.items(),
+                         indirect=False,
+                         ids=["host=%s" % p for p in shortcuts.keys()])
+def test_shortcut2gdac(short):
+    assert isinstance(shortcut2gdac(short[0]), short[1])

--- a/argopy/utils/__init__.py
+++ b/argopy/utils/__init__.py
@@ -31,6 +31,7 @@ from .lists import (
     list_radiometry_variables,
     list_radiometry_parameters,
     list_gdac_servers,
+    shortcut2gdac,
 )
 from .caching import clear_cache, lscache
 from .monitored_threadpool import MyThreadPoolExecutor as MonitoredThreadPoolExecutor

--- a/argopy/utils/lists.py
+++ b/argopy/utils/lists.py
@@ -4,7 +4,7 @@ import importlib
 import os
 import json
 from ..options import OPTIONS
-from typing import List
+from typing import List, Union
 
 path2assets = importlib.util.find_spec(
     "argopy.static.assets"
@@ -401,9 +401,44 @@ def list_gdac_servers() -> List[str]:
 
     See also
     --------
-    :class:`argopy.stores.gdacfs`, :meth:`argopy.utils.check_gdac_path`
+    :class:`argopy.gdacfs`, :meth:`argopy.utils.check_gdac_path`, :meth:`argopy.utils.shortcut2gdac`
 
     """
     with open(os.path.join(path2assets, "gdac_servers.json"), "r") as f:
         vlist = json.load(f)
-    return vlist["data"]["path"]
+    return vlist["data"]["paths"]
+
+
+def shortcut2gdac(short: str = None) -> Union[str, dict]:
+    """Shortcut to GDAC server host mapping
+
+    Parameters
+    ----------
+    short : str, optional
+        Return GDAC host for a given shortcut, otherwise return the complete dictionary mapping. If the
+        shortcut is unknown, return string unchanged.
+
+    Returns
+    -------
+    str or dict
+
+    See also
+    --------
+    :func:`argopy.utils.list_gdac_servers`, :class:`argopy.gdacfs`, :meth:`argopy.utils.check_gdac_path`
+
+    """
+    with open(os.path.join(path2assets, "gdac_servers.json"), "r") as f:
+        vlist = json.load(f)
+    shortcuts = vlist["data"]["shortcuts"]
+
+    if short is not None:
+        if short.lower().strip() in shortcuts.keys():
+            return shortcuts[short.lower().strip()]
+        else:
+            return short
+        # elif short in shortcuts.values():
+        #     return short
+        # else:
+        #     raise ValueError("This shortcut '%s' does not exist. Must be one in [%s]" % (short, shortcuts.keys()))
+    else:
+        return shortcuts

--- a/docs/advanced-tools/stores/argoindex.rst
+++ b/docs/advanced-tools/stores/argoindex.rst
@@ -66,9 +66,17 @@ You create an index store with default or custom options:
     # or:
     # ArgoIndex(index_file="argo_bio-profile_index.txt")
     # ArgoIndex(index_file="bgc-s")  # can use keyword instead of file name: core, bgc-b, bgc-b
+
     # ArgoIndex(host="ftp://ftp.ifremer.fr/ifremer/argo")
     # ArgoIndex(host="https://data-argo.ifremer.fr", index_file="core")
     # ArgoIndex(host="https://data-argo.ifremer.fr", index_file="ar_index_global_prof.txt", cache=True)
+
+Note that you can use GDAC host shortcut names:
+
+- ``https://data-argo.ifremer.fr``, shortcut with ``http`` or ``https``
+- ``https://usgodae.org/pub/outgoing/argo``, shortcut with ``us-http`` or ``us-https``
+- ``ftp://ftp.ifremer.fr/ifremer/argo``, shortcut with ``ftp``
+- ``s3://argo-gdac-sandbox/pub/idx``, shortcut with ``s3`` or ``aws``
 
 You can then trigger loading of the index content:
 

--- a/docs/advanced-tools/stores/gdac_filesystem.rst
+++ b/docs/advanced-tools/stores/gdac_filesystem.rst
@@ -29,6 +29,19 @@ Just provide a valid GDAC path, local or remote:
 
     fs
 
+You can also use shortcut for all remote GDACs:
+
+.. ipython:: python
+    :okwarning:
+
+    fs = gdacfs("http")    # or "https"    > https://data-argo.ifremer.fr
+    # or:
+    # fs = gdacfs("us-http") # or "us-https" > https://usgodae.org/pub/outgoing/argo
+    # fs = gdacfs("ftp")     #            > ftp://ftp.ifremer.fr/ifremer/argo
+    # fs = gdacfs("s3")      # or "aws"   > s3://argo-gdac-sandbox/pub
+
+
+
 Usage
 -----
 

--- a/docs/api-hidden.rst
+++ b/docs/api-hidden.rst
@@ -93,6 +93,7 @@
     argopy.utils.list_radiometry_variables
     argopy.utils.list_radiometry_parameters
     argopy.utils.list_gdac_servers
+    argopy.utils.shortcut2gdac
 
     argopy.utils.Chunker
 


### PR DESCRIPTION
New utility ``argopy.utils.shortcut2gdac`` and updated asset so that:

```python
host = OPTIONS["gdac"] if host is None else shortcut2gdac(host)
```

should be able to catch all GDAC short cut names.

This is being used by:
- ``argopy.ArgoFloat``
- ``argopy.ArgoIndex``
- ``argopy.gdacfs``
