### PR TITLE
Fix bug in fsspec handling of root path with dirfs

### DIFF
--- a/argopy/tests/helpers/utils.py
+++ b/argopy/tests/helpers/utils.py
@@ -413,4 +413,13 @@ class create_temp_folder:
             shutil.rmtree(self.folder)
 
 
+def patch_ftp(ftp):
+    """Patch Mocked FTP server keyword"""
+    if ftp == "MOCKFTP":
+        # the MOCKFTP attribute to pytest is defined in mocked_ftp.py
+        return pytest.MOCKFTP + "/."
+    else:
+        return ftp
+
+
 log.debug("%s TESTS UTILS %s" % ("="*50, "="*50))

--- a/argopy/tests/test_fetchers_data_gdac.py
+++ b/argopy/tests/test_fetchers_data_gdac.py
@@ -20,7 +20,7 @@ from argopy.errors import (
     CacheFileNotFound,
 )
 from argopy.utils.checkers import is_list_of_strings, check_gdac_path
-from utils import requires_gdac, create_temp_folder
+from utils import requires_gdac, create_temp_folder, patch_ftp
 from mocked_http import mocked_httpserver
 from mocked_http import mocked_server_address as MOCKHTTP
 
@@ -147,11 +147,7 @@ class TestBackend:
         self.cachedir = create_temp_folder().folder
 
     def _patch_gdac(self, gdac):
-        """Patch Mocked FTP server keyword"""
-        if gdac == 'MOCKFTP':
-            return pytest.MOCKFTP  # this was set in conftest.py
-        else:
-            return gdac
+        return patch_ftp(gdac)
 
     def _setup_fetcher(self, this_request, cached=False, parallel=False):
         """Helper method to set up options for a fetcher creation"""

--- a/argopy/tests/test_fetchers_index_gdac.py
+++ b/argopy/tests/test_fetchers_index_gdac.py
@@ -10,7 +10,7 @@ from argopy import IndexFetcher as ArgoIndexFetcher
 from argopy.errors import CacheFileNotFound, FileSystemHasNoCache, GdacPathError
 from argopy.utils.checkers import isconnected, is_list_of_strings
 
-from utils import requires_gdac, create_temp_folder
+from utils import requires_gdac, create_temp_folder, patch_ftp
 from mocked_http import mocked_httpserver
 from mocked_http import mocked_server_address as MOCKHTTP
 
@@ -121,11 +121,7 @@ class TestBackend:
         self.cachedir = create_temp_folder().folder
 
     def _patch_gdac(self, gdac):
-        """Patch Mocked FTP server keyword"""
-        if gdac == "MOCKFTP":
-            return pytest.MOCKFTP  # this was set in conftest.py
-        else:
-            return gdac
+        return patch_ftp(gdac)
 
     def _setup_fetcher(self, this_request, cached=False):
         """Helper method to set up options for a fetcher creation"""

--- a/argopy/tests/test_stores_float.py
+++ b/argopy/tests/test_stores_float.py
@@ -16,6 +16,8 @@ from argopy.stores.float.implementations.argo_float_offline import ArgoFloatOffl
 from argopy.stores.float.implementations.argo_float_online import ArgoFloatOnline
 
 from mocked_http import mocked_httpserver, mocked_server_address
+from utils import patch_ftp
+
 
 log = logging.getLogger("argopy.tests.floatstore")
 
@@ -94,11 +96,7 @@ class Test_FloatStore_Online():
         remove_test_dir()
 
     def _patch_ftp(self, ftp):
-        """Patch Mocked FTP server keyword"""
-        if ftp == "MOCKFTP":
-            return pytest.MOCKFTP  # this was set in conftest.py
-        else:
-            return ftp
+        return patch_ftp(ftp)
 
     def call_floatstore(self, WMO, store_args, xfail=False, reason="?"):
         def core(WMO, fargs):

--- a/argopy/tests/test_stores_fs_gdac.py
+++ b/argopy/tests/test_stores_fs_gdac.py
@@ -8,6 +8,7 @@ import xarray as xr
 import argopy
 from argopy.stores import gdacfs
 from mocked_http import mocked_httpserver, mocked_server_address
+from utils import patch_ftp
 
 """
 List gdac hosts to be tested. 
@@ -57,11 +58,7 @@ class Test_Gdacfs:
         remove_test_dir()
 
     def _patch_ftp(self, ftp):
-        """Patch Mocked FTP server keyword"""
-        if ftp == "MOCKFTP":
-            return pytest.MOCKFTP  # this was set in conftest.py
-        else:
-            return ftp
+        return patch_ftp(ftp)
 
     def call_gdacfs(self, host, xfail=False, reason="?"):
         def core(host):

--- a/argopy/tests/test_stores_index.py
+++ b/argopy/tests/test_stores_index.py
@@ -20,6 +20,8 @@ from argopy.utils.checkers import is_list_of_strings, is_wmo
 from argopy.stores import indexstore_pd, ArgoFloat
 from utils import create_temp_folder
 from mocked_http import mocked_httpserver, mocked_server_address
+from utils import patch_ftp
+
 
 log = logging.getLogger("argopy.tests.indexstores")
 
@@ -191,11 +193,7 @@ class IndexStore_test_proto:
         remove_test_dir()
 
     def _patch_ftp(self, ftp):
-        """Patch Mocked FTP server keyword"""
-        if ftp == "MOCKFTP":
-            return pytest.MOCKFTP  # this was set in conftest.py
-        else:
-            return ftp
+        return patch_ftp(ftp)
 
     def create_store(self, store_args, xfail=False, reason="?"):
         def core(fargs):


### PR DESCRIPTION
- refactor all MOCKFTP keyword patch to a single utility function
- add path "/." to mocked ftp path to fix issue with fsspec >= 2025.3.0

Note on the fsspec issue:

With fsspec >= 2025.3.0, dirfs.info now return a relative path, not an absolute one with the name key (cf https://github.com/fsspec/filesystem_spec/pull/1798)

but this seems to introduce a bug whereby fsspec can't get the relative path to a dirfs based on a root path.
I raised an issue at fsspec: https://github.com/fsspec/filesystem_spec/issues/1809

The fix for argopy is to introduce a "/." to the ftp mocked server