### PR TITLE
BGC optic diagnostic

### DIFF
--- a/argopy/extensions/__init__.py
+++ b/argopy/extensions/__init__.py
@@ -1,6 +1,7 @@
 from .utils import register_argo_accessor, ArgoAccessorExtension
 from .canyon_med import CanyonMED
 from .params_data_mode import ParamsDataMode
+from .bgc_optical_modeling import OpticalModeling
 
 #
 __all__ = (
@@ -8,4 +9,5 @@ __all__ = (
     "ArgoAccessorExtension",
     "CanyonMED",
     "ParamsDataMode",
+    "OpticalModeling",
 )

--- a/argopy/extensions/bgc_optical_modeling.py
+++ b/argopy/extensions/bgc_optical_modeling.py
@@ -1,0 +1,37 @@
+from ..utils.optical_modeling import Z_euphotic
+from . import register_argo_accessor, ArgoAccessorExtension
+
+
+@register_argo_accessor('optic')
+class OpticalModeling(ArgoAccessorExtension):
+    """Optical modeling of the upper ocean
+
+    Examples
+    --------
+    .. code-block:: python
+        :caption: Example 1
+
+        >>> from argopy import DataFetcher
+        >>> ds = Datafetcher(ds='bgc', mode='expert', params='DOWNWELLING_PAR').float(6901864).data
+        >>> dsp = ds.argo.point2profile()
+        >>> dsp.argo.optic.Zeu()
+
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def Zeu(self, par='DOWNWELLING_PAR', axis='PRES'):
+        """Compute depth of the euphotic zone
+
+        This is the depth at which the downwelling irradiance is reduced to 1% of its surface value.
+
+        The surface value is taken as the maximum `PAR` above `max_surface`.
+
+        The downwelling irradiance is from the photosynthetically available radiation: PAR.
+        """
+        da = self._argo.reduce_profile(Z_euphotic, par, axis)
+        da.name = 'Zeu'
+        da.attrs = {'long_name': 'Depth of the euphotic zone',
+                    'units': self._obj[axis].attrs.get('units', '?'),
+                    'definition': 'Depth at which the downwelling irradiance is reduced to 1% of its surface value.'}
+        return da

--- a/argopy/utils/optical_modeling.py
+++ b/argopy/utils/optical_modeling.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+
+def Z_euphotic(depth: np.array, PAR: np.array, max_surface: float = 5.) -> float:
+    """Compute depth of the euphotic zone
+
+    This is the depth at which the downwelling irradiance is reduced to 1% of its surface value.
+
+    The surface value is taken as the maximum `PAR` above `max_surface`.
+
+    The downwelling irradiance is from the photosynthetically available radiation: PAR.
+
+    Parameters
+    ----------
+    depth :
+    PAR :
+
+    Returns
+    -------
+    Euphotic layer depth estimate
+    """
+    idx = np.logical_or(np.isnan(depth), np.isnan(PAR))
+    depth = depth[~idx]
+    PAR = PAR[~idx]
+
+    try:
+        Surface_levels = np.where(depth <= max_surface)[0]
+    except:
+        Surface_levels = np.array()
+        pass
+
+    result = np.nan
+    if Surface_levels.shape[0] > 0:
+        Surface_value = np.max(PAR[Surface_levels])
+        if np.any(PAR > (Surface_value / 100)):
+            index_1_percent = np.argmin(np.abs(PAR - (Surface_value / 100)))
+            result = depth[index_1_percent]
+
+    return np.array(result)


### PR DESCRIPTION
Some preliminary new stuff for BGC, in particular:
- computing optical modelling parameters from vertical profiles, like the euphotic layer from PAR

```python
from argopy import DataFetcher
ds = Datafetcher(ds='bgc', mode='expert', params='DOWNWELLING_PAR').float(6901864).data
dsp = ds.argo.point2profile()
dsp.argo.optic.Zeu()
```