### PR TITLE
Quick plotting features for an ArgoFloat

### DIFF
--- a/argopy/plot/plot.py
+++ b/argopy/plot/plot.py
@@ -647,6 +647,13 @@ def scatter_plot(
         x_bounds, y_bounds = np.meshgrid(x, y, indexing="ij")
     c = ds[this_param]
 
+    # Possibly broadcast x,y on c dimensions:
+    if not x.shape == y.shape or not x.shape == c.shape or not y.shape == c.shape:
+        x = x.broadcast_like(c)
+        y = y.broadcast_like(c)
+        assert x.shape == y.shape
+        assert y.shape == c.shape
+
     #
     fig, ax = plt.subplots(dpi=90, figsize=figsize)
 
@@ -655,9 +662,9 @@ def scatter_plot(
     if vmax == "attrs":
         vmax = c.attrs["valid_max"] if "valid_max" in c.attrs else None
     if vmin is None:
-        vmin = np.percentile(c, 10)
+        vmin = np.nanpercentile(c, 10)
     if vmax is None:
-        vmax = np.percentile(c, 90)
+        vmax = np.nanpercentile(c, 90)
 
     if "INTERPOLATED" in this_y:
         m = ax.pcolormesh(x_bounds, y_bounds, c, cmap=cmap, vmin=vmin, vmax=vmax)

--- a/docs/api-hidden.rst
+++ b/docs/api-hidden.rst
@@ -391,3 +391,7 @@
     argopy.ArgoFloat.metadata
     argopy.ArgoFloat.N_CYCLES
     argopy.ArgoFloat.dac
+    argopy.ArgoFloat.plot
+    argopy.ArgoFloat.plot.trajectory
+    argopy.ArgoFloat.plot.scatter
+    argopy.ArgoFloat.plot.map

--- a/docs/user-guide/working-with-argo-data/visualisation.rst
+++ b/docs/user-guide/working-with-argo-data/visualisation.rst
@@ -11,7 +11,7 @@ Data visualisation
 From Data or Index fetchers
 ***************************
 
-The :class:`DataFetcher` and :class:`IndexFetcher` come with a ``plot`` method to have a quick look to your data. This method can take *trajectory*, *profiler*, *dac* and *qc_altimetry* as arguments. All details are available in the :class:`DataFetcher.plot` and :class:`IndexFetcher.plot` class documentation.
+The :class:`DataFetcher` come with a ``plot`` method to have a quick look to your data. This method can take *trajectory*, *profiler*, *dac* and *qc_altimetry* as arguments. All details are available in the :class:`DataFetcher.plot` class documentation.
 
 Below we demonstrate major plotting features.
 
@@ -53,6 +53,17 @@ If you have `Seaborn <https://seaborn.pydata.org/>`_ installed, you can change t
     fig, ax = idx.plot('profiler', style='whitegrid')
 
 .. image:: ../../_static/bar_profiler.png
+
+From ArgoFloat instance
+***********************
+
+The :class:`ArgoFloat` class come with a ``plot`` accessor than can take several methods to quickly visualize data from the float.
+
+.. code-block:: python
+
+    from argopy import ArgoFloat
+
+    ArgoFloat(6902772).plot.trajectory()
 
 
 Dashboards

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -15,6 +15,10 @@ Coming up next
 
     This new **argopy** version requires Python 3.11 !
 
+Features and front-end API
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- :class:`ArgoFloat` **plotting features**: you can now use the new :class:`ArgoFloat.plot` attribute to call on visualizations tool for trajectories and parameters. See all details in :ref:`data-viz`_. (:pr:``) by |gmaze|.
 
 Internals
 ^^^^^^^^^


### PR DESCRIPTION
This PR implements a ``plot`` accessor for the :class:`ArgoFloat` class.
This accessor can take several methods to quickly visualize data from a float.
This is basically an ad hoc shortcut to calling argopy.plot methods.

```python
from argopy import ArgoFloat

ArgoFloat(6902772).plot.trajectory()
ArgoFloat(6902772).plot.scatter('TEMP')
ArgoFloat(6902772).plot.scatter('PSAL')
```

## PR to-do list:
- [ ] Add new feature (ArgoFloat.plot accessor)
- [ ] Check coverage and unit-test
- [ ] Update the documentation
