### PR TITLE
Argo index plot extension

### DIFF
--- a/argopy/plot/__init__.py
+++ b/argopy/plot/__init__.py
@@ -10,7 +10,7 @@ See Also
 from .plot import plot_trajectory, bar_plot, open_sat_altim_report, scatter_map, scatter_plot
 from .argo_colors import ArgoColors
 from .dashboards import open_dashboard as dashboard
-from .utils import latlongrid
+from .utils import latlongrid, ARGOPY_COLORS
 
 
 __all__ = (
@@ -27,4 +27,5 @@ __all__ = (
 
     # Utils:
     "latlongrid",
+    "ARGOPY_COLORS",
 )

--- a/argopy/plot/argo_colors.py
+++ b/argopy/plot/argo_colors.py
@@ -1,6 +1,6 @@
 import numpy as np
 from packaging import version
-from .utils import has_mpl, has_seaborn
+from .utils import has_mpl, has_seaborn, ARGOPY_COLORS
 from ..utils.loggers import warnUnless
 
 if has_mpl:
@@ -40,12 +40,7 @@ class ArgoColors:
     }
     """Dictionary with number of colors in known quantitative maps"""
 
-    COLORS = {'CYAN': (18 / 256, 235 / 256, 229 / 256),
-              'BLUE': (16 / 256, 137 / 256, 182 / 256),
-              'DARKBLUE': (10 / 256, 89 / 256, 162 / 256),
-              'YELLOW': (229 / 256, 174 / 256, 41 / 256),
-              'DARKYELLOW': (224 / 256, 158 / 256, 37 / 256),
-              }
+    COLORS = ARGOPY_COLORS.copy()
     """Set of Argo colors derived from the logo"""
 
     def __init__(self, name: str = "Set1", N: int = None):

--- a/argopy/plot/plot.py
+++ b/argopy/plot/plot.py
@@ -147,7 +147,7 @@ def plot_trajectory(
 ):
     """Plot trajectories for an Argo index dataframe
 
-    This function is called by the Data fetcher and ArgoIndex methods 'plot' with the 'trajectory' option:
+    This function is called by the Data fetcher and :class:`ArgoIndex` plotting methods for trajectories:
 
     Examples
     --------

--- a/argopy/plot/plot.py
+++ b/argopy/plot/plot.py
@@ -286,24 +286,20 @@ def bar_plot(
     """Create a bar plot for an Argo index dataframe
 
 
-    This is the method called when using the facade fetcher methods ``plot`` with the ``dac`` or ``profiler`` arguments::
+    Pass a :class:`pandas.DataFrame` as returned by a :class:`argopy.DataFetcher.index` or :class:`argopy.ArgoIndex.to_dataframe` ::
 
-        IndexFetcher(src='gdac').region([-80,-30,20,50,'2021-01','2021-08']).plot('dac')
-
-    To use it directly, you must pass a :class:`pandas.DataFrame` as returned by a :class:`argopy.DataFetcher.index` or :class:`argopy.IndexFetcher.index` property::
-
-        from argopy import IndexFetcher
-        df = IndexFetcher(src='gdac').region([-80,-30,20,50,'2021-01','2021-08']).index
+        from argopy import DataFetcher
+        df = DataFetcher(src='gdac').region([-80,-30,20,50,'2021-01','2021-08']).index
         bar_plot(df, by='profiler')
 
     Parameters
     ----------
     df: :class:`pandas.DataFrame`
-        As returned by a fetcher index property
+        As returned by an argopy index dataframe
     by: str, default='institution'
         The profile property to plot
     style: str, optional
-        Define the Seaborn axes style: 'white', 'darkgrid', 'whitegrid', 'dark', 'ticks'
+        Define the Seaborn axes style: 'argopy', 'white', 'darkgrid', 'whitegrid', 'dark', 'ticks'
 
     Returns
     -------

--- a/argopy/plot/plot.py
+++ b/argopy/plot/plot.py
@@ -252,7 +252,10 @@ def plot_trajectory(
                 ax.get_yaxis().set_visible(False)
         else:
             if set_global:
-                ax.set_xlim(-180, 180)
+                if OPTIONS["longitude_convention"] == "360":
+                    ax.set_xlim(0, 360)
+                else:  # OPTIONS["longitude_convention"] == "180":
+                    ax.set_xlim(-180, 180)
                 ax.set_ylim(-90, 90)
             ax.grid(visible=True, linewidth=1, color="gray", alpha=0.7, linestyle=":")
 

--- a/argopy/plot/utils.py
+++ b/argopy/plot/utils.py
@@ -2,6 +2,8 @@ import numpy as np
 from contextlib import contextmanager
 import importlib
 
+from ..options import OPTIONS
+
 
 def _importorskip(modname):
     try:
@@ -118,7 +120,6 @@ def latlongrid(
     dy="auto",
     fontsize="auto",
     label_style_arg={},
-    longitude_convention="180",
     **kwargs
 ):
     """Add latitude/longitude grid line and labels to a cartopy geoaxes
@@ -143,7 +144,7 @@ def latlongrid(
     defaults = {"linewidth": 0.5, "color": "gray", "alpha": 0.5, "linestyle": ":"}
     gl = ax.gridlines(crs=ax.projection, draw_labels=True, **{**defaults, **kwargs})
     if dx != "auto":
-        if longitude_convention == "180":
+        if OPTIONS['longitude_convention'] == "180":
             gl.xlocator = mticker.FixedLocator(np.arange(-180, 180 + 1, dx))
         else:  # 360
             gl.xlocator = mticker.FixedLocator(np.arange(0, 360 + 1, dx))

--- a/argopy/plot/utils.py
+++ b/argopy/plot/utils.py
@@ -18,8 +18,53 @@ has_seaborn = _importorskip("seaborn")
 has_ipython = _importorskip("IPython")
 has_ipywidgets = _importorskip("ipywidgets")
 
-STYLE = {"axes": "whitegrid", "palette": "Set1"}  # Default styles
-
+STYLE = {"axes": "argopy", "palette": "Set1"}  # Default styles
+ARGOPY_COLORS = {
+    "CYAN": (18 / 256, 235 / 256, 229 / 256),
+    "BLUE": (16 / 256, 137 / 256, 182 / 256),
+    "DARKBLUE": (10 / 256, 89 / 256, 162 / 256),
+    "YELLOW": (229 / 256, 174 / 256, 41 / 256),
+    "DARKYELLOW": (224 / 256, 158 / 256, 37 / 256),
+}
+ARGOPY_STYLE = {
+    "axes.facecolor": "white",
+    "axes.edgecolor": ARGOPY_COLORS["DARKBLUE"],
+    "axes.grid": True,
+    "axes.axisbelow": "line",
+    "axes.labelcolor": ARGOPY_COLORS["BLUE"],
+    "figure.facecolor": "white",
+    "grid.color": ARGOPY_COLORS["DARKBLUE"],
+    "grid.linestyle": ":",
+    "text.color": ARGOPY_COLORS["DARKBLUE"],
+    "xtick.color": ARGOPY_COLORS["BLUE"],
+    "ytick.color": ARGOPY_COLORS["BLUE"],
+    # 'lines.solid_capstyle': <CapStyle.projecting: 'projecting'>,
+    "patch.edgecolor": "black",
+    "patch.force_edgecolor": False,
+    "image.cmap": "viridis",
+    "font.family": ["sans-serif"],
+    "font.sans-serif": [
+        "DejaVu Sans",
+        "Bitstream Vera Sans",
+        "Computer Modern Sans Serif",
+        "Lucida Grande",
+        "Verdana",
+        "Geneva",
+        "Lucid",
+        "Arial",
+        "Helvetica",
+        "Avant Garde",
+        "sans-serif",
+    ],
+    "xtick.bottom": True,
+    "xtick.top": False,
+    "ytick.left": True,
+    "ytick.right": False,
+    "axes.spines.left": True,
+    "axes.spines.bottom": True,
+    "axes.spines.right": True,
+    "axes.spines.top": True,
+}
 
 if has_mpl:
     import matplotlib as mpl  # noqa: F401
@@ -41,30 +86,42 @@ else:
     land_feature = ()
 
 if has_seaborn:
-    STYLE["axes"] = "dark"
+    # STYLE["axes"] = "dark"
     import seaborn as sns
 
 
 @contextmanager
 def axes_style(style: str = STYLE["axes"]):
-    """ Provide a context for plots
+    """Provide a context for plots
 
-        The point is to handle the availability of :mod:`seaborn` or not and to be able to use::
+    The point is to handle the availability of :mod:`seaborn` or not and to be able to use::
 
-            with axes_style(style):
-                fig, ax = plt.subplots()
+        with axes_style(style):
+            fig, ax = plt.subplots()
 
-        in all situations.
+    in all situations.
     """
     if has_seaborn:  # Execute within a seaborn context:
-        with sns.axes_style(style):
-            yield
+        if style == "argopy":
+            with sns.axes_style('whitegrid', rc=ARGOPY_STYLE):
+                yield
+        else:
+            with sns.axes_style(style):
+                yield
     else:  # Otherwise do nothing
         yield
 
 
-def latlongrid(ax, dx="auto", dy="auto", fontsize="auto", label_style_arg={}, longitude_convention='180', **kwargs):
-    """ Add latitude/longitude grid line and labels to a cartopy geoaxes
+def latlongrid(
+    ax,
+    dx="auto",
+    dy="auto",
+    fontsize="auto",
+    label_style_arg={},
+    longitude_convention="180",
+    **kwargs
+):
+    """Add latitude/longitude grid line and labels to a cartopy geoaxes
 
     Parameters
     ----------
@@ -86,7 +143,7 @@ def latlongrid(ax, dx="auto", dy="auto", fontsize="auto", label_style_arg={}, lo
     defaults = {"linewidth": 0.5, "color": "gray", "alpha": 0.5, "linestyle": ":"}
     gl = ax.gridlines(crs=ax.projection, draw_labels=True, **{**defaults, **kwargs})
     if dx != "auto":
-        if longitude_convention == '180':
+        if longitude_convention == "180":
             gl.xlocator = mticker.FixedLocator(np.arange(-180, 180 + 1, dx))
         else:  # 360
             gl.xlocator = mticker.FixedLocator(np.arange(0, 360 + 1, dx))

--- a/argopy/stores/index/argo_index.py
+++ b/argopy/stores/index/argo_index.py
@@ -117,6 +117,34 @@ class ArgoIndex(indexstore):
         >>>     print(a_float.WMO)
         >>>     ds = a_float.open_dataset('prof')
 
+    .. code-block:: python
+        :caption: Trajectory map
+
+        >>> idx = idx.query.wmo(6903091)
+        >>> idx.plot.trajectory()
+
+    .. code-block:: python
+        :caption: Trajectory map with custom arguments
+
+        >>> idx = ArgoIndex(index_file='bgc-s')
+        >>> idx.query.params('CHLA')
+
+        >>> idx.plot.trajectory(set_global=1,
+        >>>                     add_legend=0,
+        >>>                     traj=0,
+        >>>                     cbar=False,
+        >>>                     markersize=12,
+        >>>                     markeredgesize=0.1,
+        >>>                     dpi=120,
+        >>>                     figsize=(20,20));
+
+    .. code-block:: python
+        :caption: Bar plot
+
+        >>> idx.plot.bar(by='dac', index=1)
+        >>> idx.plot.bar(by='profiler')
+
+
     """
 
     def __init__(self, **kwargs):

--- a/argopy/stores/index/argo_index.py
+++ b/argopy/stores/index/argo_index.py
@@ -33,116 +33,116 @@ class ArgoIndex(indexstore):
     .. code-block:: python
         :caption: An index store is instantiated with a host (any access path, local, http or ftp) and an index file
 
-        >>> idx = ArgoIndex()
-        >>> idx = ArgoIndex(host="https://data-argo.ifremer.fr")  # Default host
-        >>> idx = ArgoIndex(host="ftp://ftp.ifremer.fr/ifremer/argo", index_file="ar_index_global_prof.txt")  # Default index
-        >>> idx = ArgoIndex(index_file="bgc-s")  # Use keywords instead of exact file names
-        >>> idx = ArgoIndex(host="https://data-argo.ifremer.fr", index_file="bgc-b", cache=True)  # Use cache for performances
-        >>> idx = ArgoIndex(host=".", index_file="dummy_index.txt", convention="core")  # Load your own index
+        idx = ArgoIndex()
+        idx = ArgoIndex(host="https://data-argo.ifremer.fr")  # Default host
+        idx = ArgoIndex(host="ftp://ftp.ifremer.fr/ifremer/argo", index_file="ar_index_global_prof.txt")  # Default index
+        idx = ArgoIndex(index_file="bgc-s")  # Use keywords instead of exact file names
+        idx = ArgoIndex(host="https://data-argo.ifremer.fr", index_file="bgc-b", cache=True)  # Use cache for performances
+        idx = ArgoIndex(host=".", index_file="dummy_index.txt", convention="core")  # Load your own index
 
     .. code-block:: python
         :caption: Full index methods and properties
 
-        >>> idx.load()
-        >>> idx.load(nrows=12)  # Only load the first N rows of the index
-        >>> idx.to_dataframe(index=True)  # Convert index to user-friendly :class:`pandas.DataFrame`
-        >>> idx.to_dataframe(index=True, nrows=2)  # Only returns the first nrows of the index
-        >>> idx.N_RECORDS  # Shortcut for length of 1st dimension of the index array
-        >>> idx.index  # internal storage structure of the full index (:class:`pyarrow.Table` or :class:`pandas.DataFrame`)
-        >>> idx.shape  # shape of the full index array
-        >>> idx.uri_full_index  # List of absolute path to files from the full index table column 'file'
+        idx.load()
+        idx.load(nrows=12)  # Only load the first N rows of the index
+        idx.to_dataframe(index=True)  # Convert index to user-friendly :class:`pandas.DataFrame`
+        idx.to_dataframe(index=True, nrows=2)  # Only returns the first nrows of the index
+        idx.N_RECORDS  # Shortcut for length of 1st dimension of the index array
+        idx.index  # internal storage structure of the full index (:class:`pyarrow.Table` or :class:`pandas.DataFrame`)
+        idx.shape  # shape of the full index array
+        idx.uri_full_index  # List of absolute path to files from the full index table column 'file'
 
     .. code-block:: python
         :caption: Search methods
 
-        >>> idx.query.wmo(1901393)
-        >>> idx.query.cyc(1)
-        >>> idx.query.wmo_cyc(1901393, [1,12])
+        idx.query.wmo(1901393)
+        idx.query.cyc(1)
+        idx.query.wmo_cyc(1901393, [1,12])
 
-        >>> idx.query.lat([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
-        >>> idx.query.lon([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
-        >>> idx.query.date([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
-        >>> idx.query.lon_lat([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
-        >>> idx.query.box([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
+        idx.query.lat([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
+        idx.query.lon([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
+        idx.query.date([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
+        idx.query.lon_lat([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
+        idx.query.box([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])  # Take an index BOX definition
 
-        >>> idx.query.params(['C1PHASE_DOXY', 'DOWNWELLING_PAR'])  # Take a list of strings, only for BGC index !
-        >>> idx.query.parameter_data_mode({'BBP700': 'D', 'DOXY': ['A', 'D']})  # Take a dict.
+        idx.query.params(['C1PHASE_DOXY', 'DOWNWELLING_PAR'])  # Take a list of strings, only for BGC index !
+        idx.query.parameter_data_mode({'BBP700': 'D', 'DOXY': ['A', 'D']})  # Take a dict.
 
-        >>> idx.query.profiler_type(845)
-        >>> idx.query.profiler_label('NINJA')
+        idx.query.profiler_type(845)
+        idx.query.profiler_label('NINJA')
 
     .. code-block:: python
         :caption: Composing search methods
 
-        >>> idx.query.compose({'box': BOX, 'wmo': WMOs})
-        >>> idx.query.compose({'box': BOX, 'params': 'DOXY'})
-        >>> idx.query.compose({'box': BOX, 'params': (['DOXY', 'DOXY2'], {'logical': 'and'})})
-        >>> idx.query.compose({'params': 'DOXY', 'profiler_label': 'ARVOR'})
+        idx.query.compose({'box': BOX, 'wmo': WMOs})
+        idx.query.compose({'box': BOX, 'params': 'DOXY'})
+        idx.query.compose({'box': BOX, 'params': (['DOXY', 'DOXY2'], {'logical': 'and'})})
+        idx.query.compose({'params': 'DOXY', 'profiler_label': 'ARVOR'})
 
     .. code-block:: python
         :caption: Search result properties and methods
 
-        >>> idx.N_MATCH  # Shortcut for length of 1st dimension of the search results array
-        >>> idx.search  # Internal table with search results
-        >>> idx.uri  # List of absolute path to files from the search results table column 'file'
+        idx.N_MATCH  # Shortcut for length of 1st dimension of the search results array
+        idx.search  # Internal table with search results
+        idx.uri  # List of absolute path to files from the search results table column 'file'
 
-        >>> idx.run()  # Run the search and save results in cache if necessary
-        >>> idx.to_dataframe()  # Convert search results to user-friendly :class:`pandas.DataFrame`
-        >>> idx.to_dataframe(nrows=2)  # Only returns the first nrows of the search results
-        >>> idx.to_indexfile("search_index.txt")  # Export search results to Argo standard index file
+        idx.run()  # Run the search and save results in cache if necessary
+        idx.to_dataframe()  # Convert search results to user-friendly :class:`pandas.DataFrame`
+        idx.to_dataframe(nrows=2)  # Only returns the first nrows of the search results
+        idx.to_indexfile("search_index.txt")  # Export search results to Argo standard index file
 
     .. code-block:: python
         :caption: List of file properties
 
-        >>> idx.read_wmo()
-        >>> idx.read_dac_wmo()
-        >>> idx.read_params()
-        >>> idx.read_domain()
-        >>> idx.read_files()
+        idx.read_wmo()
+        idx.read_dac_wmo()
+        idx.read_params()
+        idx.read_domain()
+        idx.read_files()
 
-        >>> idx.records_per_wmo()
+        idx.records_per_wmo()
 
     .. code-block:: python
         :caption: Misc
 
-        >>> idx.convention  # What is the expected index format (core vs BGC profile index)
-        >>> idx.cname
-        >>> idx.domain # the default read_domain() output, as a property
-        >>> idx.copy(deep=False)
+        idx.convention  # What is the expected index format (core vs BGC profile index)
+        idx.cname
+        idx.domain # the default read_domain() output, as a property
+        idx.copy(deep=False)
 
     .. code-block:: python
         :caption: Iterate on :class:`argopy.ArgoFloat` instance
 
-        >>> for a_float in idx.iterfloats():
-        >>>     print(a_float.WMO)
-        >>>     ds = a_float.open_dataset('prof')
+        for a_float in idx.iterfloats():
+            print(a_float.WMO)
+            ds = a_float.open_dataset('prof')
 
     .. code-block:: python
         :caption: Trajectory map
 
-        >>> idx = idx.query.wmo(6903091)
-        >>> idx.plot.trajectory()
+        idx = idx.query.wmo(6903091)
+        idx.plot.trajectory()
 
     .. code-block:: python
         :caption: Trajectory map with custom arguments
 
-        >>> idx = ArgoIndex(index_file='bgc-s')
-        >>> idx.query.params('CHLA')
+        idx = ArgoIndex(index_file='bgc-s')
+        idx.query.params('CHLA')
 
-        >>> idx.plot.trajectory(set_global=1,
-        >>>                     add_legend=0,
-        >>>                     traj=0,
-        >>>                     cbar=False,
-        >>>                     markersize=12,
-        >>>                     markeredgesize=0.1,
-        >>>                     dpi=120,
-        >>>                     figsize=(20,20));
+        idx.plot.trajectory(set_global=1,
+                            add_legend=0,
+                            traj=0,
+                            cbar=False,
+                            markersize=12,
+                            markeredgesize=0.1,
+                            dpi=120,
+                            figsize=(20,20));
 
     .. code-block:: python
         :caption: Bar plot
 
-        >>> idx.plot.bar(by='dac', index=1)
-        >>> idx.plot.bar(by='profiler')
+        idx.plot.bar(by='dac', index=1)
+        idx.plot.bar(by='profiler')
 
 
     """

--- a/argopy/stores/index/extensions.py
+++ b/argopy/stores/index/extensions.py
@@ -525,28 +525,12 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 class ArgoIndexPlotProto(ArgoIndexExtension):
     """Extension providing plot methods
 
-    Examples
-    --------
-    .. code-block:: python
-        :caption: Examples of plotting methods
-
-        from argopy import ArgoIndex
-
-        idx = ArgoIndex().query.wmo(6903091)
-
-        idx.plot.trajectory()
-        idx.plot.trajectory(figsize=(18,18), padding=[1, 5])
-
-    See Also
-    --------
-    :class:`argopy.stores.ArgoIndex.plot.trajectory`
-
     """
 
     def __call__(self, *args, **kwargs) -> NoReturn:
         raise ValueError(
             "ArgoIndex.plot cannot be called directly. Use "
-            "an explicit plot method, e.g. ArgoIndex.plot.trajectory(...)"
+            "an explicit plot method, e.g. ArgoIndex.plot.bar(...)"
         )
 
     def get_title(self, index=False):

--- a/argopy/stores/index/implementations/pandas/__init__.py
+++ b/argopy/stores/index/implementations/pandas/__init__.py
@@ -1,2 +1,2 @@
 from .index import indexstore
-from .search_engine import SearchEngine  # this import will register the searchengine, don't remove
+from .search_engine import SearchEngine  # this import will register the .query accessor, don't remove

--- a/argopy/stores/index/implementations/pandas/search_engine.py
+++ b/argopy/stores/index/implementations/pandas/search_engine.py
@@ -5,44 +5,14 @@ from typing import List
 
 from .....errors import InvalidDatasetStructure
 from .....utils import is_indexbox, check_wmo, check_cyc, to_list, conv_lon
-from .....utils import register_accessor
-from ...extensions import ArgoIndexSearchEngine
+from ...extensions import register_ArgoIndex_accessor, ArgoIndexSearchEngine
 from ..index_s3 import search_s3
 from .index import indexstore
 
 log = logging.getLogger("argopy.stores.index.pd")
 
 
-def register_ArgoIndex_accessor(name):
-    """A decorator to register an accessor as a custom property on :class:`ArgoIndex` objects.
-
-    Parameters
-    ----------
-    name : str
-        Name under which the accessor should be registered. A warning is issued
-        if this name conflicts with a preexisting attribute.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        @register_ArgoIndex_accessor('query')
-        class SearchEngine(ArgoIndexExtension):
-
-             def __init__(self, *args, **kwargs):
-                 super().__init__(*args, **kwargs)
-
-             def wmo(self, WMOs):
-                 return WMOs
-
-    It will be available to an ArgoIndex object, like this::
-
-        ArgoIndex().query.wmo(WMOs)
-    """
-    return register_accessor(name, indexstore)
-
-
-@register_ArgoIndex_accessor('query')
+@register_ArgoIndex_accessor('query', indexstore)
 class SearchEngine(ArgoIndexSearchEngine):
 
     @search_s3

--- a/argopy/stores/index/implementations/plot.py
+++ b/argopy/stores/index/implementations/plot.py
@@ -12,8 +12,10 @@ class ArgoIndexPlot(ArgoIndexPlotProto):
 
         Parameters
         ----------
+        index: bool, default=False
+            Determine if the method makes a plot with the full index (True) or only the query search result (False).
         **kwargs
-            All arguments are passed to :meth:`argopy.plot.plot_trajectory`.
+            All other arguments are passed to :meth:`argopy.plot.plot_trajectory`.
 
         Returns
         -------

--- a/argopy/stores/index/implementations/plot.py
+++ b/argopy/stores/index/implementations/plot.py
@@ -121,8 +121,6 @@ class ArgoIndexPlot(ArgoIndexPlotProto):
         """
         if by not in ['date', 'latitude', 'longitude', 'ocean', 'profiler_code', 'institution_code', 'date_update', 'wmo', 'cyc', 'institution', 'dac', 'profiler']:
             raise ValueError('Invalid value for "by", must be in "date", "latitude", "longitude", "ocean", "profiler_code"')
-        if 'by' in kwargs:
-            kwargs.pop('by')
         fig, ax = bar_plot(
                 self._obj.to_dataframe(index=index),
                 by = by,

--- a/argopy/stores/index/implementations/plot.py
+++ b/argopy/stores/index/implementations/plot.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+from ....plot import plot_trajectory, bar_plot
+from ..extensions import ArgoIndexPlotProto
+
+
+class ArgoIndexPlot(ArgoIndexPlotProto):
+    """Extension providing plot methods"""
+
+    def trajectory(self, index:bool=False, **kwargs) -> Any:
+        """Quick map of profile index trajectories
+
+        Parameters
+        ----------
+        **kwargs
+            All arguments are passed to :meth:`argopy.plot.plot_trajectory`.
+
+        Returns
+        -------
+        tuple
+            Output from :class:`argopy.plot.plot_trajectory`, typically:
+                - fig: :class:`matplotlib.figure.Figure`
+                - ax: :class:`matplotlib.axes.Axes`
+
+        Examples
+        --------
+        .. code-block:: python
+
+            from argopy import ArgoIndex
+
+            idx = ArgoIndex().query.wmo(WMO)
+            idx.plot.trajectory()
+        """
+        default_opts = {'style': 'white'}
+        N = len(self._obj.read_wmo(index=index))
+        if N == 1:
+            default_opts['hue'] = 'cyc'
+            default_opts['add_legend'] = False
+            default_opts['palette'] = 'Spectral_r'
+            default_opts['cbar'] = True
+        fig, ax = plot_trajectory(
+                self._obj.to_dataframe(index=index),
+                **{**default_opts, **kwargs}
+        )
+        ax.set_title(self.get_title(index))
+        return fig, ax
+
+    def bar(self, by: str='dac', index:bool=False, **kwargs) -> Any:
+        """Bar plot of one index property
+
+        Parameters
+        ----------
+        by: str, default='dac'
+            The index property to plot, one in 'date', 'latitude', 'longitude', 'ocean', 'profiler_code', 'institution_code', 'date_update', 'wmo', 'cyc', 'institution', 'dac', 'profiler'.
+
+        **kwargs
+            All other arguments are passed to :meth:`argopy.plot.bar_plot`.
+
+        Returns
+        -------
+        tuple
+            Output from :class:`argopy.plot.plot_trajectory`, typically:
+                - fig: :class:`matplotlib.figure.Figure`
+                - ax: :class:`matplotlib.axes.Axes`
+
+        Examples
+        --------
+        .. code-block:: python
+
+            from argopy import ArgoIndex
+
+            idx = ArgoIndex()
+            idx.plot.bar('institution')
+        """
+        if by not in ['date', 'latitude', 'longitude', 'ocean', 'profiler_code', 'institution_code', 'date_update', 'wmo', 'cyc', 'institution', 'dac', 'profiler']:
+            raise ValueError('Invalid value for "by", must be in "date", "latitude", "longitude", "ocean", "profiler_code"')
+        if 'by' in kwargs:
+            kwargs.pop('by')
+        fig, ax = bar_plot(
+                self._obj.to_dataframe(index=index),
+                by = by,
+                **kwargs
+        )
+        ax.set_title(self.get_title(index))
+        return fig, ax

--- a/argopy/stores/index/implementations/plot.py
+++ b/argopy/stores/index/implementations/plot.py
@@ -5,7 +5,52 @@ from ..extensions import ArgoIndexPlotProto
 
 
 class ArgoIndexPlot(ArgoIndexPlotProto):
-    """Extension providing plot methods"""
+    """Extension providing plot methods
+
+    Examples
+    --------
+    .. code-block:: python
+        :caption: Example of :class:`ArgoIndex` trajectory plotting method
+
+        from argopy import ArgoIndex
+
+        idx = ArgoIndex().query.wmo(6903091)
+
+        idx.plot.trajectory()
+
+    .. code-block:: python
+        :caption: Examples of :class:`ArgoIndex` trajectory plotting methods with custom arguments
+
+        from argopy import ArgoIndex
+
+        idx = ArgoIndex(index_file='bgc-s')
+        idx.query.params('CHLA')
+
+        idx.plot.trajectory(set_global=1,
+                            add_legend=0,
+                            traj=0,
+                            cbar=False,
+                            markersize=12,
+                            markeredgesize=0.1,
+                            dpi=120,
+                            figsize=(20,20));
+
+    .. code-block:: python
+        :caption: Example of :class:`ArgoIndex` bar plotting methods
+
+        from argopy import ArgoIndex
+
+        idx = ArgoIndex().load()
+
+        idx.plot.bar(by='profiler')
+
+        idx.plot.bar(by='dac')
+
+    See Also
+    --------
+    :class:`ArgoIndex.plot.trajectory`, :class:`ArgoIndex.plot.bar`
+
+    """
 
     def trajectory(self, index:bool=False, **kwargs) -> Any:
         """Quick map of profile index trajectories

--- a/argopy/stores/index/implementations/pyarrow/__init__.py
+++ b/argopy/stores/index/implementations/pyarrow/__init__.py
@@ -1,2 +1,2 @@
 from .index import indexstore
-from .search_engine import SearchEngine  # this import will register the searchengine, don't remove
+from .search_engine import SearchEngine  # this import will register the .query accessor, don't remove

--- a/argopy/stores/index/implementations/pyarrow/search_engine.py
+++ b/argopy/stores/index/implementations/pyarrow/search_engine.py
@@ -13,44 +13,14 @@ except ModuleNotFoundError:
 
 from .....errors import InvalidDatasetStructure
 from .....utils import is_indexbox, check_wmo, check_cyc, to_list, conv_lon
-from .....utils import register_accessor
-from ...extensions import ArgoIndexSearchEngine
+from ...extensions import register_ArgoIndex_accessor, ArgoIndexSearchEngine
 from ..index_s3 import search_s3
 from .index import indexstore
 
 log = logging.getLogger("argopy.stores.index.pa")
 
 
-def register_ArgoIndex_accessor(name):
-    """A decorator to register an accessor as a custom property on :class:`ArgoIndex` objects.
-
-    Parameters
-    ----------
-    name : str
-        Name under which the accessor should be registered. A warning is issued
-        if this name conflicts with a preexisting attribute.
-
-    Examples
-    --------
-    .. code-block:: python
-
-        @register_ArgoIndex_accessor('query')
-        class SearchEngine(ArgoIndexExtension):
-
-             def __init__(self, *args, **kwargs):
-                 super().__init__(*args, **kwargs)
-
-             def wmo(self, WMOs):
-                 return WMOs
-
-    It will be available to an ArgoIndex object, like this::
-
-        ArgoIndex().query.wmo(WMOs)
-    """
-    return register_accessor(name, indexstore)
-
-
-@register_ArgoIndex_accessor('query')
+@register_ArgoIndex_accessor('query', indexstore)
 class SearchEngine(ArgoIndexSearchEngine):
 
     @search_s3

--- a/argopy/stores/index/spec.py
+++ b/argopy/stores/index/spec.py
@@ -1,6 +1,7 @@
 import copy
 import numpy as np
 import pandas as pd
+import xarray as xr
 import logging
 import time
 from abc import ABC, abstractmethod
@@ -25,6 +26,7 @@ from ...utils import deprecated
 
 from .. import httpstore, memorystore, filestore, ftpstore, s3store
 from .implementations.index_s3 import get_a_s3index
+from .implementations.plot import ArgoIndexPlot
 
 try:
     import pyarrow.csv as csv  # noqa: F401
@@ -1180,3 +1182,6 @@ file,profiler_type,institution,date_update
         else:
             for wmo in wmos:
                 yield ArgoFloat(wmo, idx=self)
+
+    # Possibly register extensions without specific implementations:
+    plot = xr.core.utils.UncachedAccessor(ArgoIndexPlot)

--- a/argopy/tests/test_stores_index_plot.py
+++ b/argopy/tests/test_stores_index_plot.py
@@ -1,0 +1,73 @@
+import pytest
+import logging
+import importlib
+
+import argopy
+from argopy.stores import ArgoIndex
+
+from utils import (
+    requires_gdac,
+    requires_matplotlib,
+    requires_cartopy,
+    has_matplotlib,
+    has_cartopy,
+)
+
+if has_matplotlib:
+    import matplotlib as mpl
+
+if has_cartopy:
+    import cartopy
+
+log = logging.getLogger("argopy.tests.indexstores.plot")
+argopy.clear_cache()
+
+
+"""
+Select GDAC host to be use for plot accessor test 
+"""
+VALID_HOST = argopy.tutorial.open_dataset("gdac")[0]  # Use local files
+# 'http1': mocked_server_address,  # Use the mocked http server
+# 'http2': 'https://data-argo.ifremer.fr',
+# 'ftp': "MOCKFTP",  # keyword to use a fake/mocked ftp server (running on localhost)
+
+"""
+List WMO to be tested, one for each mission
+"""
+VALID_WMO = [13857, 3902131]
+
+
+@requires_gdac
+@requires_matplotlib
+class Test_IndexStore_PlotAccessor:
+
+    @requires_cartopy
+    @pytest.mark.parametrize(
+        "wmo", VALID_WMO, indirect=False, ids=[f"wmo={w}" for w in VALID_WMO]
+    )
+    def test_plot_trajectory(self, wmo):
+        fig, ax = ArgoIndex(host=VALID_HOST, cache=True).query.wmo(wmo).plot.trajectory()
+        assert isinstance(fig, mpl.figure.Figure)
+        assert isinstance(ax, cartopy.mpl.geoaxes.GeoAxesSubplot)
+        mpl.pyplot.close(fig)
+
+    @pytest.mark.parametrize(
+        "by", ['dac'], indirect=False, ids=[f"by='{w}'" for w in ['dac']]
+    )
+    @pytest.mark.parametrize(
+        "index", [True, False], indirect=False, ids=[f"index={c}" for c in [True, False]]
+    )
+    def test_plot_bar(self, by, index):
+        idx = ArgoIndex(host=VALID_HOST, cache=True)
+
+        fig, ax = idx.plot.bar(by=by, index=index)
+        assert isinstance(fig, mpl.figure.Figure)
+        assert isinstance(ax, mpl.axes.Axes)
+        mpl.pyplot.close(fig)
+
+
+    def test_plot_bar_errors(self):
+        idx = ArgoIndex(host=VALID_HOST, cache=True)
+
+        with pytest.raises(ValueError):
+            idx.plot.bar(by="NOT_A_VALID_PARAM")

--- a/argopy/utils/casting.py
+++ b/argopy/utils/casting.py
@@ -209,6 +209,8 @@ def to_list(obj):
     if not isinstance(obj, list):
         if isinstance(obj, np.ndarray):
             obj = list(obj)
+        elif isinstance(obj, tuple):
+            obj = [o for o in obj]
         else:
             obj = [obj]
     return obj

--- a/argopy/utils/decorators.py
+++ b/argopy/utils/decorators.py
@@ -216,7 +216,7 @@ class _CachedAccessor:
 
     def __get__(self, obj, cls):
         if obj is None:
-            # we're accessing the attribute of the class, i.e., Dataset.argo.canyon
+            # we're accessing the attribute of the class, i.e., Dataset.argo.extension
             return self._accessor
 
         # Use the same dict as @pandas.util.cache_readonly.

--- a/docs/api-hidden.rst
+++ b/docs/api-hidden.rst
@@ -333,6 +333,10 @@
     argopy.ArgoIndex.query.box
     argopy.ArgoIndex.query.compose
 
+    argopy.ArgoIndex.plot
+    argopy.ArgoIndex.plot.trajectory
+    argopy.ArgoIndex.plot.bar
+
     argopy.stores.index.implementations.index_s3.s3index
     argopy.stores.index.implementations.index_s3.s3index_core
     argopy.stores.index.implementations.index_s3.s3index_bgc_bio

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -116,6 +116,7 @@ List of extensions:
    :template: autosummary/accessor.rst
 
    ArgoIndex.query
+   ArgoIndex.plot
 
 **Search on a single property** of a file record:
 
@@ -144,6 +145,14 @@ List of extensions:
    ArgoIndex.query.box
    ArgoIndex.query.compose
 
+**Ploting methods**:
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/accessor_method.rst
+
+    ArgoIndex.plot.trajectory
+    ArgoIndex.plot.bar
 
 Argo meta/related data
 ======================

--- a/docs/user-guide/working-with-argo-data/visualisation.rst
+++ b/docs/user-guide/working-with-argo-data/visualisation.rst
@@ -86,6 +86,38 @@ The :class:`ArgoFloat` class come with a :class:`ArgoFloat.plot` accessor than c
 
 Check all the detailed arguments on the API reference :class:`ArgoFloat.plot`.
 
+From ArgoIndex instance
+************************
+
+.. currentmodule:: argopy
+
+The :class:`ArgoIndex` class come with a :class:`ArgoIndex.plot` accessor than can take several methods to quickly visualize data from the float:
+
+.. code-block:: python
+
+    from argopy import ArgoIndex
+
+    idx = ArgoIndex(index_file='bgc-s')
+    idx.query.params('CHLA')
+
+    idx.plot.trajectory()
+
+    idx.plot.trajectory(set_global=1,
+                        add_legend=0,
+                        traj=0,
+                        cbar=False,
+                        markersize=12,
+                        markeredgesize=0.1,
+                        dpi=120,
+                        figsize=(20,20));
+
+    idx.plot.bar(by='profiler')
+
+    idx.plot.bar(by='dac')
+
+Check all the detailed arguments on the API reference :class:`ArgoIndex.plot`.
+
+
 Dashboards
 **********
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,6 +18,8 @@ Coming up next
 Features and front-end API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- :class:`ArgoIndex` **plotting features**: you can now use the new :class:`ArgoIndex.plot` accessor to call on visualizations tool for trajectories or parameters bar plots. See all details on the documentation section about data visualization :ref:`From ArgoIndex instance`. (:pr:`504`) by |gmaze|.
+
 - :class:`ArgoFloat` **plotting features**: you can now use the new :class:`ArgoFloat.plot` accessor to call on visualizations tool for trajectories and parameters. See all details on the documentation section about data visualization :ref:`From ArgoFloat instance`. (:pr:`501`) by |gmaze|.
 
 Internals


### PR DESCRIPTION
Same idea as #501 but for the ArgoIndex

This PR implements a ``plot`` accessor for the `ArgoIndex` class.
This accessor can take several methods to quickly visualize data from the full index or search result.
This is basically an ad hoc shortcut to calling argopy.plot methods.

```python
from argopy import ArgoIndex

idx = ArgoIndex()
idx.plot.bar(by='profiler')
idx.plot.bar(by='dac')

idx.query.wmo(6903091)
idx.plot.trajectory()
```

## PR to-do list:
- [x] Add new feature (ArgoIndex.plot accessor)
- [x] Check coverage and unit-test
- [x] Update the documentation
