### PR TITLE
Update http request header user agent

### DIFF
--- a/argopy/stores/filesystems.py
+++ b/argopy/stores/filesystems.py
@@ -1,5 +1,6 @@
 import os
 import fsspec
+import aiohttp
 import logging
 import importlib
 from typing import Union
@@ -40,7 +41,7 @@ except ModuleNotFoundError:
 
 
 USER_AGENT: str = "Python/{0[0]}.{0[1]} aiohttp/{1} Argopy/{2} (+https://github.com/euroargodev/argopy)".format(
-    sys.version_info, fsspec.implementations.http.aiohttp.__version__, __version__
+    sys.version_info, aiohttp.__version__, __version__
 )
 
 

--- a/argopy/stores/filesystems.py
+++ b/argopy/stores/filesystems.py
@@ -77,6 +77,10 @@ def new_fs(
             "headers": {"User-Agent": USER_AGENT},
         }  # Passed to aiohttp.ClientSession
         if "client_kwargs" in kwargs:
+            if "headers" in kwargs['client_kwargs']:
+                for header_key, header_val in kwargs['client_kwargs']['headers'].items():
+                    client_kwargs['headers'].update({header_key: header_val})
+                kwargs['client_kwargs'].pop("headers")
             client_kwargs = {**client_kwargs, **kwargs["client_kwargs"]}
             kwargs.pop("client_kwargs")
         default_fsspec_kwargs = {

--- a/argopy/stores/filesystems.py
+++ b/argopy/stores/filesystems.py
@@ -3,6 +3,7 @@ import fsspec
 import logging
 import importlib
 from typing import Union
+import sys
 
 from ..options import OPTIONS
 from ..utils.accessories import Registry
@@ -38,6 +39,11 @@ except ModuleNotFoundError:
     distributed = None
 
 
+USER_AGENT: str = "Python/{0[0]}.{0[1]} aiohttp/{1} Argopy/{2} (+https://github.com/euroargodev/argopy)".format(
+    sys.version_info, fsspec.implementations.http.aiohttp.__version__, __version__
+)
+
+
 def new_fs(
     protocol: str = "",
     cache: bool = False,
@@ -68,7 +74,7 @@ def new_fs(
     if protocol == "http":
         client_kwargs = {
             "trust_env": OPTIONS["trust_env"],
-            "headers": {"Argopy-Version": __version__},
+            "headers": {"User-Agent": USER_AGENT},
         }  # Passed to aiohttp.ClientSession
         if "client_kwargs" in kwargs:
             client_kwargs = {**client_kwargs, **kwargs["client_kwargs"]}

--- a/argopy/stores/filesystems.py
+++ b/argopy/stores/filesystems.py
@@ -69,6 +69,11 @@ def new_fs(
     (fs, cache_registry)
         A tuple with the fsspec file system and :class:`argopy.Registry` for cache if any
 
+    Notes
+    -----
+    For the specific case of the 'http' file system, the ``client_kwargs`` argument can be used to customise HTTP requests header fields like:
+    ``httpstore(client_kwargs={"headers": {"Some-Header": "a value"}})``
+
     """
     # Merge default FSSPEC kwargs with user defined kwargs:
     default_fsspec_kwargs = {"simple_links": True, "block_size": 0}

--- a/argopy/tests/helpers/mocked_http.py
+++ b/argopy/tests/helpers/mocked_http.py
@@ -161,13 +161,13 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         file_path = unquote(self.path.rstrip("/"))
-        log.debug("Requesting: '%s'" % file_path)
+        # log.debug("Requesting: '%s'" % file_path)
         # log.debug("Found: %s" % (file_path in self.files.keys()))
         # log.debug("Found B: %s" % (file_path in MOCKED_REQUESTS.keys()))
         # [log.debug("\t└─ '%s'" % k) for k in self.files.keys()]
         # [log.debug("\t└─ '%s': %s" % (k, v) for k, v in self.headers.items())]
-        log.debug("Headers: ")
-        log.debug("\n".join([f"\t└─ '{k}': {self.headers[k]}" for k in self.headers.keys()]))
+        # log.debug("Headers: ")
+        # log.debug("\n".join([f"\t└─ '{k}': {self.headers[k]}" for k in self.headers.keys()]))
 
         file_data = self.files.get(file_path)
         if "give_path" in self.headers:

--- a/argopy/tests/helpers/mocked_http.py
+++ b/argopy/tests/helpers/mocked_http.py
@@ -161,10 +161,13 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         file_path = unquote(self.path.rstrip("/"))
-        # log.debug("Requesting: '%s'" % file_path)
+        log.debug("Requesting: '%s'" % file_path)
         # log.debug("Found: %s" % (file_path in self.files.keys()))
         # log.debug("Found B: %s" % (file_path in MOCKED_REQUESTS.keys()))
         # [log.debug("\t└─ '%s'" % k) for k in self.files.keys()]
+        # [log.debug("\t└─ '%s': %s" % (k, v) for k, v in self.headers.items())]
+        log.debug("Headers: ")
+        log.debug("\n".join([f"\t└─ '{k}': {self.headers[k]}" for k in self.headers.keys()]))
 
         file_data = self.files.get(file_path)
         if "give_path" in self.headers:
@@ -190,13 +193,17 @@ class HTTPTestHandler(BaseHTTPRequestHandler):
                 file_data = file_data[-int(end) :]
             if "use_206" in self.headers:
                 status = 206
-        if "give_length" in self.headers:
-            response_headers = {"Content-Length": n}
-            self._respond(status, response_headers, file_data)
-        elif "give_range" in self.headers:
-            self._respond(status, {"Content-Range": content_range}, file_data)
-        else:
-            self._respond(status, data=file_data)
+
+        response_headers = {"Content-Length": n, "Content-Range": content_range}
+        self._respond(status, response_headers, file_data)
+
+        # if "give_length" in self.headers:
+        #     response_headers = {"Content-Length": n}
+        #     self._respond(status, response_headers, file_data)
+        # elif "give_range" in self.headers:
+        #     self._respond(status, {"Content-Range": content_range}, file_data)
+        # else:
+        #     self._respond(status, data=file_data)
 
     def do_POST(self):
         length = self.headers.get("Content-Length")

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -13,6 +13,8 @@ Coming up next (unreleased)
 Internals
 ---------
 
+- **Updated User-Agent header field for HTTP requests**. The default aiottp header field User-Agent is now complemented with Argopy information in order to ease server side log analysis. The User-Agent is now somethink like: ``"User-Agent": Python/3.11 aiohttp/3.12.14 Argopy/1.3.0 (+https://github.com/euroargodev/argopy)``, :issue:`533`. (:pr:`534`) by |gmaze|.
+
 - **New post method for the** :class:`stores.httpstore` by |gmaze|.
 
 - **Fix upstream compatibility** whereby xarray >= 2025.8 deprecation cycle for changing default keyword arguments in :meth:`xarray.merge` and :meth:`xarray.concat` would make Argopy to fail with internal data processing, :issue:`521`. (:pr:`504`) by |gmaze|.


### PR DESCRIPTION
Close #533 

In this PR we:
- remove the existing custom header ``Argopy-Version``  that is not logged by the erddap server
- modify the default [aiohttp](https://github.com/aio-libs/aiohttp/blob/b381cb4f18e470a53785bb1ef8846bce692df40a/aiohttp/client_reqrep.py#L1021) User-Agent with something like:
``"User-Agent": Python/3.11 aiohttp/3.12.14 Argopy/1.3.0 (+https://github.com/euroargodev/argopy)``


## PR to-do list
- [x] Add new feature
- [x] Update documentation/docstrings
- [x] CI tests passed