### PR TITLE
Implement a new utility to load static asset files

### DIFF
--- a/argopy/tests/test_utils_accessories.py
+++ b/argopy/tests/test_utils_accessories.py
@@ -83,4 +83,3 @@ class Test_Registry():
             Registry(opts[0][0], dtype=opts[1], invalid='warn').commit(opts[0][-1])
         # Raise nothing:
         Registry(opts[0][0], dtype=opts[1], invalid='ignore').commit(opts[0][-1])
-

--- a/argopy/tests/test_utils_locals.py
+++ b/argopy/tests/test_utils_locals.py
@@ -1,8 +1,10 @@
 import os
+
+import pandas as pd
 import pytest
 import io
 import argopy
-from argopy.utils.locals import modified_environ
+from argopy.utils.locals import modified_environ, Asset
 
 
 @pytest.mark.parametrize("conda", [False, True],
@@ -20,3 +22,22 @@ def test_modified_environ():
         assert os.environ['DUMMY_ENV_ARGOPY'] == 'toto'
     assert os.environ['DUMMY_ENV_ARGOPY'] == 'initial'
     os.environ.pop('DUMMY_ENV_ARGOPY')
+
+
+class Test_Asset():
+    assets = ['gdac_servers.json', 'data_types', 'schema:argo.sensor.schema.json', 'schema:argo.float.schema']
+    assets_id = [f"{a}" for a in assets]
+    @pytest.mark.parametrize("asset", assets, indirect=False, ids=assets_id)
+    def test_load_json(self, asset):
+        data = Asset.load(asset)
+        assert isinstance(data, dict)
+
+    assets = ['canyon-b:wgts_AT.txt']
+    assets_id = [f"{a}" for a in assets]
+    @pytest.mark.parametrize("asset", assets, indirect=False, ids=assets_id)
+    def test_load_csv(self, asset):
+        data = Asset.load(asset)
+        assert isinstance(data, pd.DataFrame)
+
+        data = Asset.load(asset, header=None, sep="\t")
+        assert isinstance(data, pd.DataFrame)

--- a/argopy/utils/__init__.py
+++ b/argopy/utils/__init__.py
@@ -43,6 +43,7 @@ from .locals import (  # noqa: F401
     modified_environ,
     get_sys_info,  # noqa: F401
     netcdf_and_hdf5_versions,  # noqa: F401
+    Asset,
 )
 from .monitors import monitor_status, badge, fetch_status  # noqa: F401
 from .geo import (
@@ -124,6 +125,7 @@ __all__ = (
     "show_versions",
     "show_options",
     "modified_environ",
+    "Asset",
     # Monitors
     "monitor_status",
     # Geo (space/time data utilities)

--- a/docs/api-hidden.rst
+++ b/docs/api-hidden.rst
@@ -80,6 +80,7 @@
 
     argopy.utils.show_versions
     argopy.utils.show_options
+    argopy.utils.Asset
 
     argopy.utils.clear_cache
     argopy.utils.lscache


### PR DESCRIPTION
In order to make static asset loading easier, we extract from ongoing #545 the new utility class **Asset**. 
This PR will also be useful to address #547 in a future PR.

Assets are loaded using an instance of :class:`argopy.stores.filestore`.

This is **single-instance** class, whereby a single instance will be created during a session, whatever the number of calls is made. This avoids to create too many, and unnecessary, instances of file stores.

```python
Asset.load('data_types')
Asset.load('data_types.json')
Asset.load('schema:argo.float.schema')
Asset.load('canyon-b:wgts_AT.txt', header=None, sep="\t")
```

If no suffix is indicated, asset is assumed to be a JSON file with a `.json` extension.

If the asset is in sub-folders, use semicolons ':' as separator (eg: 'schema:argo.float.schema').

All other arguments are passed down to the loading method.

**PR to-do**
- [x] Implement new feature
- [x] Add CI tests
- [x] Add documentation (only docstrings+api-hidden, this is an internal utility)
