### PR TITLE
Add llms.txt generation

### DIFF
--- a/ci/requirements/py3.11-docs-rtd.yml
+++ b/ci/requirements/py3.11-docs-rtd.yml
@@ -67,6 +67,7 @@ dependencies:
   - nbsphinx
   - jinja2
   - sphinx-issues
+  - sphinx-llms-txt
   - sphinx_rtd_theme
   - sphinx-book-theme
   - pydata-sphinx-theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,7 @@ extensions = [
     'sphinxext.rediraffe',
     'sphinx_copybutton',
     'sphinx_design',
+    'sphinx_llms_txt',
 ]
 
 # sphinx_gallery_conf = {

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -24,6 +24,11 @@ Breaking changes
   - column `institution_code` is renamed `institution`, to preserve the original Argo index file column name,
   - column `institution` is renamed by `institution_name`.
 
+Internals
+^^^^^^^^^
+
+- Add llms.txt generation, a file to provide information to help LLMs use **Argopy** documentation. See https://llmstxt.org for more.
+
 Energy
 ^^^^^^
 


### PR DESCRIPTION
``llms.txt`` is a file that has been adopted by many documentation websites (e.g., https://docs.xarray.dev/en/stable/llms.txt ) to make docs more readable to LLM agents.

More infor at: https://llmstxt.org

New files output:
```
./doc/_build/html/llms.txt
./doc/_build/html/llms-full.txt
```

Further config in here: https://sphinx-llms-txt.readthedocs.io/en/latest/advanced-configuration.html