### PR TITLE
Refactor ArgoIndex query parsing and update docs

### DIFF
--- a/argopy/stores/index/extensions.py
+++ b/argopy/stores/index/extensions.py
@@ -200,7 +200,7 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 
         Parameters
         ----------
-        BOX : list, tuple, int, or float, optional
+        BOX : list, tuple, int, float, optional
             An index box to search Argo records for. Can be:
             
             - Full 6-element list: [lon_min, lon_max, lat_min, lat_max, date_min, date_max]
@@ -247,7 +247,7 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 
         Parameters
         ----------
-        BOX : list, tuple, int, or float, optional
+        BOX : list, tuple, int, float, optional
             An index box to search Argo records for. Can be:
             
             - Full 6-element list: [lon_min, lon_max, lat_min, lat_max, date_min, date_max]

--- a/argopy/stores/index/extensions.py
+++ b/argopy/stores/index/extensions.py
@@ -200,10 +200,19 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 
         Parameters
         ----------
-        BOX : list(), tuple(), int, float
-            An index box to search Argo records for.
-            Use ``ge``/``le`` keyword bounds for lower/upper limits; a single value
-            (e.g., ``lon(-60)``) is treated as ``ge=-60``.
+        BOX : list, tuple, int, or float, optional
+            An index box to search Argo records for. Can be:
+            
+            - Full 6-element list: [lon_min, lon_max, lat_min, lat_max, date_min, date_max]
+            - 2-element list: [lon_min, lon_max]
+            - Single value: interpreted as lower bound (ge)
+            
+        ge : int or float, optional
+            Greater or equal bound for longitude filtering (lower limit).
+            Default: -180
+        le : int or float, optional
+            Less or equal bound for longitude filtering (upper limit).
+            Default: 180
 
         Returns
         -------
@@ -212,6 +221,10 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
         Warnings
         --------
         Only longitude bounds are used from the index box.
+
+        Notes
+        -----
+        Either ``BOX`` or ``ge``/``le`` keywords must be provided.
 
         Examples
         --------
@@ -234,10 +247,19 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 
         Parameters
         ----------
-        BOX : list(), tuple(), int, float
-            An index box to search Argo records for.
-            Use ``ge``/``le`` keyword bounds for lower/upper limits; a single value
-            (e.g., ``lat(40)``) is treated as ``ge=40``.
+        BOX : list, tuple, int, or float, optional
+            An index box to search Argo records for. Can be:
+            
+            - Full 6-element list: [lon_min, lon_max, lat_min, lat_max, date_min, date_max]
+            - 2-element list: [lat_min, lat_max]
+            - Single value: interpreted as lower bound (ge)
+            
+        ge : int or float, optional
+            Greater or equal bound for latitude filtering (lower limit).
+            Default: -90
+        le : int or float, optional
+            Less or equal bound for latitude filtering (upper limit).
+            Default: 90
 
         Returns
         -------
@@ -246,6 +268,10 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
         Warnings
         --------
         Only latitude bounds are used from the index box.
+
+        Notes
+        -----
+        Either ``BOX`` or ``ge``/``le`` keywords must be provided.
 
         Examples
         --------
@@ -268,8 +294,19 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 
         Parameters
         ----------
-        BOX : list()
-            An index box to search Argo records for.
+        BOX : list or str, optional
+            An index box to search Argo records for. Can be:
+            
+            - Full 6-element list: [lon_min, lon_max, lat_min, lat_max, date_min, date_max]
+            - 2-element list: [date_min, date_max]
+            - Single date string: interpreted as day-only (profiles on that specific date)
+            
+        ge : str, optional
+            Greater or equal bound for date filtering (lower limit).
+            Default: '1900-01-01'
+        le : str, optional
+            Less or equal bound for date filtering (upper limit).
+            Default: '2100-12-31'
 
         Returns
         -------
@@ -279,6 +316,10 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
         --------
         Only date bounds are used from the index box.
 
+        Notes
+        -----
+        Either ``BOX`` or ``ge``/``le`` keywords must be provided.
+
         Examples
         --------
         .. code-block:: python
@@ -287,6 +328,9 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
             idx = ArgoIndex(index_file='core')
 
             idx.query.date([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])
+            idx.query.date(ge='2007-08-01', le='2007-09-01')
+            idx.query.date(['2007-08-01', '2007-09-01'])
+            idx.query.date('2007-09-01')
 
         """
         raise NotImplementedError("Not implemented")

--- a/argopy/stores/index/extensions.py
+++ b/argopy/stores/index/extensions.py
@@ -200,7 +200,7 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 
         Parameters
         ----------
-        BOX : list()
+        BOX : list(), tuple() int, float
             An index box to search Argo records for.
 
         Returns

--- a/argopy/stores/index/extensions.py
+++ b/argopy/stores/index/extensions.py
@@ -200,8 +200,10 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 
         Parameters
         ----------
-        BOX : list(), tuple() int, float
+        BOX : list(), tuple(), int, float
             An index box to search Argo records for.
+            Use ``ge``/``le`` keyword bounds for lower/upper limits; a single value
+            (e.g., ``lon(-60)``) is treated as ``ge=-60``.
 
         Returns
         -------
@@ -219,7 +221,10 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
             idx = ArgoIndex(index_file='core')
 
             idx.query.lon([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])
-
+            idx.query.lon([-60, -55])
+            idx.query.lon(ge=-60)
+            idx.query.lon(le=-55)
+            idx.query.lon(-60)
         """
         raise NotImplementedError("Not implemented")
 

--- a/argopy/stores/index/extensions.py
+++ b/argopy/stores/index/extensions.py
@@ -234,8 +234,10 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
 
         Parameters
         ----------
-        BOX : list()
+        BOX : list(), tuple(), int, float
             An index box to search Argo records for.
+            Use ``ge``/``le`` keyword bounds for lower/upper limits; a single value
+            (e.g., ``lat(40)``) is treated as ``ge=40``.
 
         Returns
         -------
@@ -253,7 +255,10 @@ class ArgoIndexSearchEngine(ArgoIndexExtension):
             idx = ArgoIndex(index_file='core')
 
             idx.query.lat([-60, -55, 40., 45., '2007-08-01', '2007-09-01'])
-
+            idx.query.lat([40, 45])
+            idx.query.lat(ge=40)
+            idx.query.lat(le=45)
+            idx.query.lat(40)
         """
         raise NotImplementedError("Not implemented")
 

--- a/argopy/stores/index/implementations/pyarrow/search_engine.py
+++ b/argopy/stores/index/implementations/pyarrow/search_engine.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:
 
 from .....options import OPTIONS
 from .....errors import InvalidDatasetStructure, OptionValueError
-from .....utils import is_indexbox, check_wmo, check_cyc, to_list, conv_lon
+from .....utils import is_indexbox, parse_indexbox, check_wmo, check_cyc, to_list, conv_lon
 from ...extensions import register_ArgoIndex_accessor, ArgoIndexSearchEngine
 from ..index_s3 import search_s3
 from .index import indexstore
@@ -150,38 +150,13 @@ class SearchEngine(ArgoIndexSearchEngine):
 
     def date(self, BOX=None, nrows=None, composed=False, **kwargs):            
         def checker(BOX, **kwargs):
-            if 'ge' in kwargs or 'le' in kwargs:
-                ge = kwargs.get('ge', '1900-01-01')
-                le = kwargs.get('le', '2100-12-31')
-                BOX = [-180, 180, -90, 90, ge, le]
-
-            else:
-                match BOX:
-                    case list() if len(BOX) >= 6:
-                        pass
-                    case [vmin, vmax]:
-                        BOX = [-180, 180, -90, 90, vmin, vmax]
-                    case None:
-                        raise ValueError("Invalid arguments")
-                    case str():
-                        # Single date [date, date+1)
-                        d0 = pd.to_datetime(BOX)
-                        d1 = d0 + pd.Timedelta(days=1)
-
-                        # Convert to strings to satisfy is_indexbox validation
-                        ge = d0.strftime("%Y-%m-%d")
-                        le = d1.strftime("%Y-%m-%d")
-
-                        BOX = [-180, 180, -90, 90, ge, le]
-                    case _:
-                        raise ValueError("Unsupported argument format")
-                    
+            BOX = parse_indexbox("date", BOX, **kwargs)
             if "date" not in self._obj.convention_columns:
                 raise InvalidDatasetStructure("Cannot search for date in this index")
             is_indexbox(BOX)
             log.debug("Argo index searching for date in BOX=%s ..." % BOX)
             return ("date", BOX)  # Return key to use for time axis
-
+        
         key, BOX = checker(BOX, **kwargs)
 
         def namer(BOX):
@@ -216,23 +191,7 @@ class SearchEngine(ArgoIndexSearchEngine):
 
     def lat(self, BOX=None, nrows=None, composed=False, **kwargs):
         def checker(BOX, **kwargs):
-            if 'ge' in kwargs or 'le' in kwargs:
-                ge = kwargs.get('ge', -90.)
-                le = kwargs.get('le', 90.)
-                BOX = [-180, 180, ge, le, '1900-01-01', '2100-12-31']
-            else:
-                match BOX:
-                    case list() if len(BOX) >= 6:
-                        pass
-                    case [vmin, vmax]:
-                        BOX = [-180, 180, vmin, vmax, '1900-01-01', '2100-12-31']
-                    case None:
-                        raise ValueError("Invalid arguments")
-                    case int() | float():
-                        BOX = [-180, 180, BOX, 90, '1900-01-01', '2100-12-31']
-                    case _:
-                        raise ValueError("Unsupported argument format")
-
+            BOX = parse_indexbox("lat", BOX, **kwargs)
             if "latitude" not in self._obj.convention_columns:
                 raise InvalidDatasetStructure("Cannot search for latitude in this index")
             is_indexbox(BOX)
@@ -263,23 +222,7 @@ class SearchEngine(ArgoIndexSearchEngine):
 
     def lon(self, BOX=None, nrows=None, composed=False, **kwargs):
         def checker(BOX, **kwargs):
-            if 'ge' in kwargs or 'le' in kwargs:
-                ge = kwargs.get('ge', -180.)
-                le = kwargs.get('le', 180.)
-                BOX = [ge, le, -90, 90, '1900-01-01', '2100-12-31']
-            else:
-                match BOX:
-                    case list() if len(BOX) >= 6:
-                        pass
-                    case [vmin, vmax]:
-                        BOX = [vmin, vmax, -90, 90, '1900-01-01', '2100-12-31']
-                    case None:
-                        raise ValueError("Invalid arguments")
-                    case int() | float():
-                        BOX = [BOX, 180, -90, 90, '1900-01-01', '2100-12-31']
-                    case _:
-                        raise ValueError("Unsupported argument format")
-                    
+            BOX = parse_indexbox("lon", BOX, **kwargs)
             if "longitude" not in self._obj.convention_columns:
                 raise InvalidDatasetStructure("Cannot search for longitude in this index")
             is_indexbox(BOX)

--- a/argopy/utils/__init__.py
+++ b/argopy/utils/__init__.py
@@ -1,6 +1,7 @@
 from .checkers import (  # noqa: F401
     is_box,
     is_indexbox,
+    parse_indexbox,
     is_list_of_strings,
     is_list_of_dicts,
     is_list_of_datasets,

--- a/argopy/utils/checkers.py
+++ b/argopy/utils/checkers.py
@@ -291,56 +291,96 @@ def is_box(box: list, errors: str = "raise"):
     return True
 
 def parse_indexbox(dimension, BOX=None, **kwargs):
+    """ Parse and standardize user arguments for index box queries.x
+
+    This utility converts various user input formats (full BOX, range list, single value, or ge/le keywords)
+    into a standard 6-element index box: [lon_min, lon_max, lat_min, lat_max, date_min, date_max].
+    Used to simplify argument handling for ArgoIndex query methods (lon, lat, date).
+
+    Parameters
+    ----------
+    dimension : {'lon', 'lat', 'date'}
+        The dimension to parse. Determines which elements are set in the output box.
+    BOX : list, tuple, int, float, str, or None, optional
+        User input for the query. Can be:
+        - Full 6-element list: [lon_min, lon_max, lat_min, lat_max, date_min, date_max]
+        - 2-element list: [vmin, vmax] for the selected dimension
+        - Single value: int/float for lon/lat, str for date (interpreted as day-only)
+        - None, if using ge/le keywords
+    ge : int, float, or str, optional
+        Lower bound for the selected dimension (alternative to BOX).
+    le : int, float, or str, optional
+        Upper bound for the selected dimension (alternative to BOX).
+
+    Returns
+    -------
+    list : standardized 6-element index box.
+
+    Raises
+    ------
+    ValueError
+        If arguments are missing or unsupported.
+    TypeError
+        If a numeric value is passed for a date dimension.
+
+    Notes
+    -----
+    Either BOX or ge/le keywords must be provided.
+    For date, a single string is interpreted as a day-only filter.
+
+    Examples
+    --------
+    >>> parse_indexbox('lon', [-60, -55])
+    [-60, -55, -90, 90, '1900-01-01', '2100-12-31']
+    >>> parse_indexbox('lat', ge=40, le=45)
+    [-180, 180, 40, 45, '1900-01-01', '2100-12-31']
+    >>> parse_indexbox('date', '2007-09-01')
+    [-180, 180, -90, 90, '2007-09-01', '2007-09-02']
+
+    """
+
+    # Templates for each dimension: (lon_min, lon_max, lat_min, lat_max, date_min, date_max)
+    templates = {
+        "lon":   lambda ge, le:   [ge, le, -90., 90., '1900-01-01', '2100-12-31'],
+        "lat":   lambda ge, le:   [-180., 180., ge, le, '1900-01-01', '2100-12-31'],
+        "date":  lambda ge, le:   [-180., 180., -90., 90., ge, le],
+    }
+    # Defaults for ge/le per dimension
+    defaults = {
+        "lon":   (-180., 180.),
+        "lat":   (-90., 90.),
+        "date":  ('1900-01-01', '2100-12-31'),
+    }
+
     if 'ge' in kwargs or 'le' in kwargs:
-        match dimension:
-            case "lon" :
-                ge = kwargs.get('ge', -180.)
-                le = kwargs.get('le', 180.)
-                BOX = [ge, le, -90, 90, '1900-01-01', '2100-12-31']
-            case "lat" :
-                ge = kwargs.get('ge', -90.)
-                le = kwargs.get('le', 90.)
-                BOX = [-180, 180, ge, le, '1900-01-01', '2100-12-31']
-            case "date" :
-                ge = kwargs.get('ge', '1900-01-01')
-                le = kwargs.get('le', '2100-12-31')
-                BOX = [-180, 180, -90, 90, ge, le]    
+        ge = kwargs.get('ge', defaults[dimension][0])
+        le = kwargs.get('le', defaults[dimension][1])
+        BOX = templates[dimension](ge, le)
     else:
         match BOX:
             case list() if len(BOX) >= 6:
                 pass
             case [vmin, vmax]:
-                match dimension:
-                    case "lon" :
-                        BOX = [vmin, vmax, -90, 90, '1900-01-01', '2100-12-31']
-                    case "lat" :
-                        BOX = [-180, 180, vmin, vmax, '1900-01-01', '2100-12-31']
-                    case "date" :
-                        BOX = [-180, 180, -90, 90, vmin, vmax]
+                BOX = templates[dimension](vmin, vmax)
             case None:
                 raise ValueError("Invalid arguments")
             case int() | float():
-                match dimension:
-                    case "lon" :
-                        BOX = [BOX, 180, -90, 90, '1900-01-01', '2100-12-31']
-                    case "lat" :
-                        BOX = [-180, 180, BOX, 90, '1900-01-01', '2100-12-31']
-                    case "date" : 
-                        raise TypeError(
-                                f"Date argument must be a string (e.g., '2007-09-01'), "
-                                f"not {type(BOX).__name__}. "
-                                f"Use ge='YYYY-MM-DD' and/or le='YYYY-MM-DD' for date filtering."
-                            )
+                if dimension == "date":
+                    raise TypeError(
+                        f"Date argument must be a string (e.g., '2007-09-01'), "
+                        f"not {type(BOX).__name__}. "
+                        f"Use ge='YYYY-MM-DD' and/or le='YYYY-MM-DD' for date filtering."
+                    )
+                else:
+                    ge, le = (BOX, defaults[dimension][1])
+                    BOX = templates[dimension](ge, le)                    
             case str():
                 # Single date [date, date+1)
                 d0 = pd.to_datetime(BOX)
                 d1 = d0 + pd.Timedelta(days=1)
-
-                # Convert to strings to satisfy is_indexbox validation
                 ge = d0.strftime("%Y-%m-%d")
                 le = d1.strftime("%Y-%m-%d")
-
-                BOX = [-180, 180, -90, 90, ge, le]
+                BOX = templates["date"](ge, le)
             case _:
                 raise ValueError("Unsupported argument format")
     return BOX


### PR DESCRIPTION
## Summary
This PR factors query argument parsing for lon/lat/date and updates documentation to reflect the new bound keywords and single‑date behavior.

## Changes

- Add a shared helper that converts explicit lower/upper bounds, [min, max], or legacy BOX into a full index box
- Use helper in lon, lat and date checkers
- Update lon/lat and date docstrings with explicit bound examples and single‑date usage

