### PR TITLE
Reset N_PROF index after sorting in point2profile (fixes #632)

### DIFF
--- a/argopy/tests/test_xarray_accessor.py
+++ b/argopy/tests/test_xarray_accessor.py
@@ -58,6 +58,64 @@ def test_point2profile2point(ds_pts):
     assert ds_pts['standard'].argo.point2profile().argo.profile2point().equals(ds_pts['standard'])
 
 
+def test_point2profile_reindexes_N_PROF():
+    """point2profile must reset N_PROF to a clean 0..N-1 range (gh #632).
+
+    The profiles are built in UID (WMO/CYCLE) order but the final dataset is
+    sorted by time; the N_PROF coordinate used to keep its pre-sort labels,
+    leaving e.g. [0, 3, 1, 2] instead of [0, 1, 2, 3].
+    """
+    N_LEVELS = 3
+    # (platform, cycle, time offset in days) — deliberately so that time order
+    # differs from UID order, which is what triggers the bug:
+    profiles = [(6902, 2, 10), (6902, 1, 30), (6901, 5, 5), (6901, 9, 20)]
+    platform, cycle, day, level = [], [], [], []
+    for wmo, cyc, t in profiles:
+        for lev in range(N_LEVELS):
+            platform.append(wmo)
+            cycle.append(cyc)
+            day.append(t)
+            level.append(lev)
+    n = len(platform)
+    day = np.array(day)
+    ds = xr.Dataset(
+        {
+            "PLATFORM_NUMBER": ("N_POINTS", np.array(platform, "float64")),
+            "CYCLE_NUMBER": ("N_POINTS", np.array(cycle, "int64")),
+            "DIRECTION": ("N_POINTS", np.array(["A"] * n)),
+            "PRES": ("N_POINTS", np.array(level, "float64") + 1),
+            # vary with level so TEMP stays a [N_PROF, N_LEVELS] variable, and
+            # encode the profile time so association can be checked after sorting
+            "TEMP": ("N_POINTS", day.astype("float64") * 10 + np.array(level)),
+            "TIME": (
+                "N_POINTS",
+                np.array(
+                    [np.datetime64("2004-01-01") + np.timedelta64(int(t), "D") for t in day]
+                ),
+            ),
+            "LATITUDE": ("N_POINTS", np.ones(n)),
+            "LONGITUDE": ("N_POINTS", np.ones(n) * 2),
+        },
+        coords={"N_POINTS": np.arange(n)},
+    )
+    ds = ds.argo.cast_types()
+    ds.argo._type = "point"
+
+    profile = ds.argo.point2profile()
+
+    # N_PROF is a clean contiguous range, not the permuted pre-sort labels
+    np.testing.assert_array_equal(
+        profile["N_PROF"].values, np.arange(profile.sizes["N_PROF"])
+    )
+    # profiles are still ordered by time ...
+    assert (np.diff(profile["TIME"].values) >= np.timedelta64(0)).all()
+    # ... and each profile's data still travels with it (TEMP encodes the day)
+    expected_days = np.sort(np.unique(day))
+    np.testing.assert_array_equal(
+        profile["TEMP"].isel(N_LEVELS=0).values, expected_days * 10
+    )
+
+
 class Test_interp_std_levels:
     def test_interpolation(self, ds_pts):
         """Run with success"""

--- a/argopy/xarray.py
+++ b/argopy/xarray.py
@@ -584,7 +584,6 @@ class ArgoAccessor:
 
         # Restore coordinate variables:
         new_ds = new_ds.set_coords([c for c in coords_list if c in new_ds])
-        new_ds["N_PROF"] = np.arange(N_PROF)
         if "N_LEVELS" in new_ds["LATITUDE"].dims:
             new_ds["LATITUDE"] = new_ds["LATITUDE"].isel(
                 N_LEVELS=0
@@ -593,6 +592,9 @@ class ArgoAccessor:
 
         # Misc formatting
         new_ds = new_ds.sortby(self._TNAME)
+        # sortby reorders profiles along N_PROF, carrying the old index labels
+        # with them; reset N_PROF to a clean 0..N_PROF-1 range (gh #632)
+        new_ds["N_PROF"] = np.arange(N_PROF)
         new_ds = (
             new_ds.argo.cast_types() if not drop else cast_Argo_variable_type(new_ds)
         )

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -16,6 +16,11 @@ Features and front-end API
 
 - **Full Argo vocabulary support** for reference tables (:class:`ArgoReferenceTable`), values (:class:`ArgoReferenceValue`) and mappings (:class:`ArgoReferenceMapping`) (:pr:`575`) by |gmaze|.
 
+Internals
+^^^^^^^^^
+
+- **Fix bug** whereby :meth:`Dataset.argo.point2profile` left the ``N_PROF`` coordinate with permuted index labels instead of a clean ``0..N_PROF-1`` range, because the final sorting by time carried the pre-sort labels along. :issue:`632`. (:pr:`636`) by |gaoflow|.
+
 v1.4.0 (5 Jan. 2026)
 --------------------
 
@@ -1522,6 +1527,7 @@ v0.1.0 (17 Mar. 2020)
 .. |gmaze| replace:: `G. Maze <http://www.github.com/gmaze>`__
 .. |quai20| replace:: `K. Balem <http://www.github.com/quai20>`__
 .. |fricour| replace:: `F. Ricour <https://www.github.com/fricour>`__
+.. |gaoflow| replace:: `gaoflow <https://github.com/gaoflow>`__
 
 .. |pypi dwn| image:: https://img.shields.io/pypi/dm/argopy?label=Pypi%20downloads
    :target: //pypi.org/project/argopy/


### PR DESCRIPTION
This PR will close: #632

#### Changes proposed in this pull request

`point2profile` assigns `N_PROF = np.arange(N_PROF)` and then, as a final formatting step, runs `new_ds = new_ds.sortby(self._TNAME)`. `sortby` reorders the profiles along the `N_PROF` dimension and carries the existing index labels with them, so the `N_PROF` coordinate ends up permuted rather than a clean contiguous range. For a dataset where time order differs from UID order (e.g. multi-float BGC data) this produces the `[370, 371, 369, ..., 0, 741]`-style `N_PROF` reported in the issue.

- Move the `new_ds["N_PROF"] = np.arange(N_PROF)` assignment to *after* the `sortby`, so the time-ordered profiles get a clean `0..N_PROF-1` index.

The fix only relabels the `N_PROF` coordinate values; it does not change the row order (already set by `sortby`) or the data, so the `point2profile` → `profile2point` round-trip is unaffected.

#### Task list
- [x] CI tests added or updated

Added `test_point2profile_reindexes_N_PROF`, which builds a point dataset whose time order differs from its UID order, and asserts that after `point2profile` the `N_PROF` coordinate is `0..N-1`, that profiles remain time-sorted, and that each profile's data still travels with it. The test fails on `main` (`N_PROF` comes out `[0, 3, 1, 2]`) and passes with the fix.