### PR TITLE
add ai policy contribution section in docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -484,3 +484,73 @@ that whatever the data source set by users, the output xarray or
 dataframe will be formatted and contain the same variables. This will
 also ensure that other argopy features can be used on the new fetcher
 output, like plotting or xarray data manipulation.
+
+.. _contributing.ai_policy:
+
+Policy regarding AI powered contributions
+=========================================
+
+.. contents:: AI powered contributions:
+   :local:
+
+AI Usage Policy
+---------------
+
+The argopy developing team has set some rules for generative AI usage. These rules are not definitive and may be updated in the future.
+
+- **All generative AI usage in any form must be disclosed.** If AI was used to generate a significant
+  portion of your contribution (beyond simple autocomplete), we ask that you **disclose it** within the
+  code or PR description. You must state the tool you used along with a sentence saying that the work was AI-assisted.
+
+- **Pull requests and issues created by AI are forbidden.**
+  If AI isn't disclosed but a maintainer suspects its use within a PR or issue **creation**, the PR will be closed.
+  AI assistance can be used for discussions inside PR or issues, but must always be supervized and reviewed by a human eye before submission.
+
+- **Media.**
+  Text and code are the only acceptable AI-generated content, per the
+  other rules in this policy.
+
+These rules apply to all contributors, including maintainers. 
+
+Human Accountability
+--------------------
+
+**The human contributor is 100% responsible for the contribution.**
+
+If you submit a Pull Request that includes AI-generated code, documentation, or
+comments:
+
+- You must **fully understand** the code you submit, and the context in which it is included inside the global project or **Argopy**.
+- You must be able to explain the "**why**" behind the implementation during the
+  review process.
+- You are responsible for the long-term maintenance of that code.
+
+The people
+----------
+
+Please keep in mind that **Argopy** is developed and maintained by humans being.
+
+It is for us a fundamental aspect of the project that discussions (in issues or PR), even if happenning on github,
+are made between humans. Knowing this, it will be considered impolite to approach the **Argopy** dev community with AI-agent.
+
+Ethics, Ecology & Expertise
+---------------------------
+
+For more than 20 years, the Argo program has been a key element in the observation and understanding of climate change
+and its impact on the ocean. Argo is incremental in monitoring how the human-driven climate change negatively impact
+the ocean state and marine life (`check the IPCC special report on ocean <https://www.ipcc.ch/srocc/>`_ or
+`that brief overview also from the IPCC <https://www.ipcc.ch/report/ar6/wg1/downloads/factsheets/IPCC_AR6_WGI_Sectoral_Fact_Sheet_Marine_Ecosystems_Fisheries.pdf>`_).
+So, it is of primary and inherent concern to Argo to limit its environmental footprint.
+
+We like to think that **Argopy** is part of the Argo ecosystem.
+
+As sustainable software developers, the **Argopy** team aims to better understand the generative
+AI’s environmental impact, following our preliminary work in
+`monitoring the carbon footprint of maintaining and developing Argopy <https://argopy.readthedocs.io/en/latest/energy.html>`_.
+But very little information are available on the generative AI’s environmental impact and "current GAI models are deployed mainly
+in carbon-intensive regions" (`Ding et al, 2025 <https://doi.org/10.1016/j.xinn.2025.100866>`_).
+
+With that, 2 things to keep in mind when contributing to the development of **Argopy** :
+
+- **Ethics & Ecology** : Not knowing the - presumably very large - impact of generative AI on CO2 emissions (and use of limited Earth resources), it is important to us that we adopt a conservative and limited approach regarding GAI usage in contributing to **Argopy** in order to limit its environmental footprint.
+- **Expertise** : **Argopy**, as part of a public research infrastructure, has more duty in developing/preserving a technical and scientific expertise for the public good, than participating in a blind race to productivity gain (in the `social acceleration sense <https://en.wikipedia.org/wiki/Social_acceleration>`_, an argument echoing the `slow science <https://en.wikipedia.org/wiki/Slow_science>`_ approach at work within **Argopy**). It is thus also important to us that we adopt a conservative and limited approach regarding GAI usage in contributing to **Argopy** to preserve a good level of human expertise regarding the produced code and our associated ability to disseminate our expertise to the end-users.

--- a/docs/energy.rst
+++ b/docs/energy.rst
@@ -5,7 +5,7 @@ Carbon emissions
 
 Why
 ---
-The **argopy** team is concerned about the environmental impact of your favorite software development activities.
+The **argopy** team is concerned about the environmental impact of your favorite software development activities. See for instance our position on `AI powered contributions <https://argopy.readthedocs.io/en/latest/contributing.html#id46>`_ to **argopy**.
 
 Starting June 1st 2024, we're experimenting with the `Green Metrics Tools <https://metrics.green-coding.io>`_ from `Green Coding <https://www.green-coding.io>`_ to get an estimate of the energy used and CO2eq emitted by our development activities on Github infrastructure.
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -23,6 +23,10 @@ Internals
 
 - **Fix bug** where by some unit tests would raise  `fsspec.exceptions.FSTimeoutError`, :issue:`593`. (:pr:`640`) by |gmaze|.
 
+Documentation
+^^^^^^^^^^^^^
+
+- **Define** a policy regarding **generative AI usage** in **argopy** contributions :issue:`637`. (:pr:`639`) by |quai20|.
 
 v1.4.0 (5 Jan. 2026)
 --------------------


### PR DESCRIPTION
Still linked to #637 

- [x] the text should be added to the [Contribution page](https://argopy.readthedocs.io/en/latest/contributing.html), probably as new full section.

- [x] this new section could then be mentioned in the [Carbon emissions page](https://argopy.readthedocs.io/en/latest/energy.html)

- [x] Also, the [What's New page](https://argopy.readthedocs.io/en/latest/whats-new.html) should be updated