### PR TITLE
Make trajectory plots picklisable

### DIFF
--- a/argopy/plot/utils.py
+++ b/argopy/plot/utils.py
@@ -77,11 +77,23 @@ if has_mpl:
 if has_cartopy:
     import cartopy
     import cartopy.feature as cfeature
-    from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+    # from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
+    from cartopy.mpl.gridliner import _east_west_formatted, _north_south_formatted
 
     land_feature = cfeature.NaturalEarthFeature(
         category="physical", name="land", scale="50m", facecolor=[0.4, 0.6, 0.7]
     )
+
+    def tox(v, pos=None):
+        return _east_west_formatted(v)
+
+    LONGITUDE_FORMATTER = mticker.FuncFormatter(tox)
+
+    def toy(v, pos=None):
+        return _north_south_formatted(v)
+
+    LATITUDE_FORMATTER = mticker.FuncFormatter(toy)
+
 else:
     land_feature = ()
 
@@ -103,7 +115,7 @@ def axes_style(style: str = STYLE["axes"]):
     """
     if has_seaborn:  # Execute within a seaborn context:
         if style == "argopy":
-            with sns.axes_style('whitegrid', rc=ARGOPY_STYLE):
+            with sns.axes_style("whitegrid", rc=ARGOPY_STYLE):
                 yield
         else:
             with sns.axes_style(style):
@@ -112,14 +124,7 @@ def axes_style(style: str = STYLE["axes"]):
         yield
 
 
-def latlongrid(
-    ax,
-    dx="auto",
-    dy="auto",
-    fontsize="auto",
-    label_style_arg={},
-    **kwargs
-):
+def latlongrid(ax, dx="auto", dy="auto", fontsize="auto", label_style_arg={}, **kwargs):
     """Add latitude/longitude grid line and labels to a cartopy geoaxes
 
     Parameters
@@ -139,8 +144,15 @@ def latlongrid(
     """
     if not isinstance(ax, cartopy.mpl.geoaxes.GeoAxesSubplot):
         raise ValueError("Please provide a cartopy.mpl.geoaxes.GeoAxesSubplot instance")
-    defaults = {"linewidth": 0.5, "color": ARGOPY_COLORS['BLUE'], "alpha": 0.5, "linestyle": ":"}
-    gl = ax.gridlines(crs=cartopy.crs.PlateCarree(), draw_labels=True, **{**defaults, **kwargs})
+    defaults = {
+        "linewidth": 0.5,
+        "color": ARGOPY_COLORS["BLUE"],
+        "alpha": 0.5,
+        "linestyle": ":",
+    }
+    gl = ax.gridlines(
+        crs=cartopy.crs.PlateCarree(), draw_labels=True, **{**defaults, **kwargs}
+    )
     if dx != "auto":
         gl.xlocator = mticker.FixedLocator(np.arange(-180, 180 + 1, dx))
     if dy != "auto":

--- a/argopy/tests/test_plot_plot.py
+++ b/argopy/tests/test_plot_plot.py
@@ -5,7 +5,9 @@ This file covers the argopy.plot.plot submodule
 import pytest
 from unittest.mock import patch
 import logging
+import tempfile
 from typing import Callable
+import pickle
 
 import argopy
 from utils import (
@@ -100,11 +102,14 @@ class Test_plot_trajectory:
     src = "gdac"
     local_gdac = argopy.tutorial.open_dataset("gdac")[0]
     requests = {
+        "float": [[2901623]],
         # "float": [[2901623], [2901623, 6901929, 5906072]],
         # "profile": [[2901623, 12], [6901929, [5, 45]]],
         "region": [
-            [-60, -40, 40.0, 60.0, 0.0, 10.0],
-            [-60, -40, 40.0, 60.0, 0.0, 10.0, "2007-08-01", "2007-09-01"],
+            # [-60, -40, 40.0, 60.0, 0.0, 10.0],
+            # [-60, -40, 40.0, 60.0, 0.0, 10.0, "2007-08-01", "2007-09-01"]
+            [-20, -16.0, 0, 1, 0, 100.0],
+            # [-20, -16.0, 0, 1, 0, 100.0, "1997-07-01", "1997-09-01"],
         ],
     }
 
@@ -139,14 +144,33 @@ class Test_plot_trajectory:
         expected_lg_type = mpl.legend.Legend if with_legend else type(None)
         assert isinstance(ax.get_legend(), expected_lg_type)
 
+        try:
+            with tempfile.NamedTemporaryFile(delete=True, mode='wb') as fid:
+                pickle.dump(fig, fid)
+        except:
+            raise
+
         mpl.pyplot.close(fig)
 
     @pytest.mark.parametrize("opts", opts, indirect=False, ids=opts_ids)
+    def test_with_a_float(self, opts):
+        if 'float' in self.requests:
+            with argopy.set_options(src=self.src, gdac=self.local_gdac):
+                for arg in self.requests["float"]:
+                    loader = DataFetcher(cache=False).float(arg).load()
+                    self.__test_traj_plot(loader.index, opts)
+        else:
+            pytest.xfail("Because no WMO available in coverage")
+
+    @pytest.mark.parametrize("opts", opts, indirect=False, ids=opts_ids)
     def test_with_a_region(self, opts):
-        with argopy.set_options(src=self.src, gdac=self.local_gdac):
-            for arg in self.requests["region"]:
-                loader = DataFetcher(cache=True).region(arg).load()
-                self.__test_traj_plot(loader.index, opts)
+        if 'region' in self.requests:
+            with argopy.set_options(src=self.src, gdac=self.local_gdac):
+                for arg in self.requests["region"]:
+                    loader = DataFetcher(cache=False).region(arg).load()
+                    self.__test_traj_plot(loader.index, opts)
+        else:
+            pytest.xfail("Because no BOX available in coverage")
 
 
 @requires_gdac
@@ -158,8 +182,10 @@ class Test_bar_plot:
         # "float": [[2901623], [2901623, 6901929, 5906072]],
         # "profile": [[2901623, 12], [6901929, [5, 45]]],
         "region": [
-            [-60, -40, 40.0, 60.0, 0.0, 10.0],
-            [-60, -40, 40.0, 60.0, 0.0, 10.0, "2007-08-01", "2007-09-01"],
+            # [-60, -40, 40.0, 60.0, 0.0, 10.0],
+            # [-60, -40, 40.0, 60.0, 0.0, 10.0, "2007-08-01", "2007-09-01"],
+            [-20, -16.0, 0, 1, 0, 100.0],
+            [-20, -16.0, 0, 1, 0, 100.0, "1997-07-01", "1997-09-01"],
         ],
     }
 
@@ -192,8 +218,10 @@ class Test_scatter_map:
         # "float": [[2901623], [2901623, 6901929, 5906072]],
         # "profile": [[2901623, 12], [6901929, [5, 45]]],
         "region": [
-            [-60, -40, 40.0, 60.0, 0.0, 10.0],
-            [-60, -40, 40.0, 60.0, 0.0, 10.0, "2007-08-01", "2007-09-01"],
+            # [-60, -40, 40.0, 60.0, 0.0, 10.0],
+            # [-60, -40, 40.0, 60.0, 0.0, 10.0, "2007-08-01", "2007-09-01"],
+            [-20, -16.0, 0, 1, 0, 100.0],
+            [-20, -16.0, 0, 1, 0, 100.0, "1997-07-01", "1997-09-01"],
         ],
     }
 
@@ -226,7 +254,7 @@ class Test_scatter_map:
     def test_with_a_dataset_of_points(self, opts):
         with argopy.set_options(src=self.src, gdac=self.local_gdac):
             for arg in self.requests["region"]:
-                loader = DataFetcher(cache=True).region(arg).load()
+                loader = DataFetcher(cache=False).region(arg).load()
                 with pytest.raises(InvalidDatasetStructure):
                     self.__test(loader.data, (None, None, None), opts)
 
@@ -234,7 +262,7 @@ class Test_scatter_map:
     def test_with_a_dataset_of_profiles(self, opts):
         with argopy.set_options(src=self.src, gdac=self.local_gdac):
             for arg in self.requests["region"]:
-                loader = DataFetcher(cache=True).region(arg).load()
+                loader = DataFetcher(cache=False).region(arg).load()
                 dsp = loader.data.argo.point2profile()
                 # with pytest.warns(UserWarning):
                 #     self.__test(dsp, (None, None, None), opts)
@@ -244,7 +272,7 @@ class Test_scatter_map:
     def test_with_a_dataframe_of_index(self, opts):
         with argopy.set_options(src=self.src, gdac=self.local_gdac):
             for arg in self.requests["region"]:
-                loader = DataFetcher(cache=True).region(arg).load()
+                loader = DataFetcher(cache=False).region(arg).load()
                 self.__test(loader.index, (None, None, None), opts)
 
 
@@ -260,7 +288,7 @@ class Test_scatter_plot:
     def setup_ds(self):
         """Create a real xarray Dataset for all tests."""
         self.ds = (
-            DataFetcher(src=self.src, gdac=self.local_gdac, cache=True)
+            DataFetcher(src=self.src, gdac=self.local_gdac, cache=False)
             .region([-60, -40, 40.0, 60.0, 0.0, 10.0])
             .data
         )


### PR DESCRIPTION
Fix a bug whereby a trajectory plot cannot be pickled.
Closes #656 

This is high priority for the next release because it is required by the pydox calibration library.


The issue is coming from the `argopy.plot.utils.latlongrid` method that is using `LONGITUDE_FORMATTER` and `LATITUDE_FORMATTER` from `cartopy.mpl.gridliner`. 
**The bug is that these are lambda functions that can't be pickled.**

The fix is to overwrite `LONGITUDE_FORMATTER` and `LATITUDE_FORMATTER` in Argopy as:
```python
from cartopy.mpl.gridliner import _east_west_formatted, _north_south_formatted

def tox(v, pos=None):
    return _east_west_formatted(v)
LONGITUDE_FORMATTER = mticker.FuncFormatter(tox)
    
def toy(v, pos=None):
    return _north_south_formatted(v)
LATITUDE_FORMATTER = mticker.FuncFormatter(toy)
```

This is not fully satisfactory because Argopy will now rely on Cartopy private functions ``_east_west_formatted`` and ``_north_south_formatted``.
I should raise an issue at Cartopy and propose this fix, so that this is pushed upstream of Argopy


